### PR TITLE
feat: staff invite creation shell and student landing route

### DIFF
--- a/apps/web/app/s/[token]/page.tsx
+++ b/apps/web/app/s/[token]/page.tsx
@@ -1,0 +1,178 @@
+import { Button, Card, PageShell } from "@begifted/ui";
+import type { CSSProperties } from "react";
+
+interface StudentLandingProps {
+  params: Promise<{ token: string }>;
+}
+
+const tealGradient =
+  "radial-gradient(circle at top left, rgba(20, 184, 166, 0.25), transparent 36%), linear-gradient(180deg, #f0fdfa 0%, #f5f3ff 100%)";
+
+const accentBar: CSSProperties = {
+  width: 42,
+  height: 6,
+  borderRadius: 999,
+  background: "linear-gradient(90deg, #0f766e, #14b8a6)",
+  marginBottom: 18,
+};
+
+const tagline: CSSProperties = {
+  margin: 0,
+  textTransform: "uppercase",
+  letterSpacing: "0.16em",
+  fontSize: 12,
+  color: "#0f766e",
+};
+
+const heading: CSSProperties = {
+  margin: "8px 0 12px",
+  fontSize: "clamp(1.6rem, 3vw, 2.4rem)",
+  lineHeight: 1.15,
+};
+
+const body: CSSProperties = {
+  margin: 0,
+  fontSize: 16,
+  lineHeight: 1.7,
+  color: "#44403c",
+  maxWidth: 540,
+};
+
+const stepGrid: CSSProperties = {
+  display: "grid",
+  gap: 16,
+};
+
+const stepCard: CSSProperties = {
+  display: "flex",
+  gap: 16,
+  alignItems: "flex-start",
+};
+
+const stepNumber: CSSProperties = {
+  flexShrink: 0,
+  width: 36,
+  height: 36,
+  borderRadius: 12,
+  background: "rgba(15, 118, 110, 0.08)",
+  color: "#0f766e",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontWeight: 700,
+  fontSize: 15,
+};
+
+const stepTitle: CSSProperties = {
+  margin: "0 0 2px",
+  fontSize: 15,
+  fontWeight: 600,
+  color: "#1f2937",
+};
+
+const stepDesc: CSSProperties = {
+  margin: 0,
+  fontSize: 14,
+  lineHeight: 1.5,
+  color: "#57534e",
+};
+
+const steps = [
+  {
+    number: "1",
+    title: "Verify your details",
+    description:
+      "Confirm your name and the assessments assigned to you before starting.",
+  },
+  {
+    number: "2",
+    title: "Complete the pre-test",
+    description:
+      "Answer each section at your own pace. Your progress is saved automatically.",
+  },
+  {
+    number: "3",
+    title: "Submit your responses",
+    description:
+      "Review your answers and submit. You won't be able to change responses after submission.",
+  },
+];
+
+export default async function StudentLandingPage({
+  params,
+}: StudentLandingProps) {
+  const { token } = await params;
+
+  // Token validation will call GET /api/public/invites/:token once backend is ready.
+  // For now we render the shell unconditionally.
+
+  return (
+    <PageShell maxWidth={600} gradient={tealGradient}>
+      <Card accent="#0f766e">
+        <div style={accentBar} />
+        <p style={tagline}>BeGifted Assessment</p>
+        <h1 style={heading}>Welcome to your pre-test</h1>
+        <p style={body}>
+          You&rsquo;ve been invited to complete an academic assessment. This
+          helps your instructor understand your current level and recommend the
+          best learning path for you.
+        </p>
+      </Card>
+
+      <Card accent="#0f766e">
+        <h2
+          style={{
+            margin: "0 0 16px",
+            fontSize: 17,
+            fontWeight: 600,
+            color: "#292524",
+          }}
+        >
+          How it works
+        </h2>
+        <div style={stepGrid}>
+          {steps.map((step) => (
+            <div key={step.number} style={stepCard}>
+              <div style={stepNumber}>{step.number}</div>
+              <div>
+                <p style={stepTitle}>{step.title}</p>
+                <p style={stepDesc}>{step.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      <Card accent="#0f766e" style={{ textAlign: "center" as const }}>
+        <p
+          style={{
+            margin: "0 0 16px",
+            fontSize: 14,
+            color: "#57534e",
+            lineHeight: 1.5,
+          }}
+        >
+          When you&rsquo;re ready, click below to begin. Make sure you have a
+          quiet space and enough time to finish without interruption.
+        </p>
+        <Button
+          style={{
+            background: "linear-gradient(135deg, #0f766e, #14b8a6)",
+            boxShadow: "0 4px 14px rgba(15, 118, 110, 0.3)",
+          }}
+        >
+          Begin assessment
+        </Button>
+        <p
+          style={{
+            margin: "12px 0 0",
+            fontSize: 12,
+            color: "#a8a29e",
+          }}
+        >
+          Invite token: {token.slice(0, 8)}&hellip;
+        </p>
+      </Card>
+    </PageShell>
+  );
+}

--- a/apps/web/app/staff/invites/new/page.tsx
+++ b/apps/web/app/staff/invites/new/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { Button, Card, PageShell, TextInput } from "@begifted/ui";
+import type { CSSProperties, FormEvent } from "react";
+import { useState } from "react";
+
+const headerAccent: CSSProperties = {
+  width: 42,
+  height: 6,
+  borderRadius: 999,
+  background: "linear-gradient(90deg, #b45309, #d97706)",
+  marginBottom: 18,
+};
+
+const tagline: CSSProperties = {
+  margin: 0,
+  textTransform: "uppercase",
+  letterSpacing: "0.16em",
+  fontSize: 12,
+  color: "#b45309",
+};
+
+const heading: CSSProperties = {
+  margin: "8px 0 8px",
+  fontSize: "clamp(1.6rem, 3vw, 2.4rem)",
+  lineHeight: 1.15,
+};
+
+const subtitle: CSSProperties = {
+  margin: 0,
+  fontSize: 15,
+  lineHeight: 1.6,
+  color: "#57534e",
+  maxWidth: 560,
+};
+
+const divider: CSSProperties = {
+  border: "none",
+  borderTop: "1px solid rgba(148,163,184,0.2)",
+  margin: "8px 0",
+};
+
+const sectionLabel: CSSProperties = {
+  margin: "0 0 16px",
+  fontSize: 17,
+  fontWeight: 600,
+  color: "#292524",
+};
+
+const chipRow: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  marginTop: 4,
+};
+
+const chip: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
+  padding: "5px 12px",
+  borderRadius: 999,
+  fontSize: 13,
+  background: "rgba(180, 83, 9, 0.08)",
+  color: "#92400e",
+  border: "1px solid rgba(180, 83, 9, 0.15)",
+};
+
+const removeBtn: CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  color: "#92400e",
+  fontSize: 14,
+  padding: 0,
+  lineHeight: 1,
+  fontFamily: "inherit",
+};
+
+export default function NewInvitePage() {
+  const [studentName, setStudentName] = useState("");
+  const [parentEmail, setParentEmail] = useState("");
+  const [recipientInput, setRecipientInput] = useState("");
+  const [recipientEmails, setRecipientEmails] = useState<string[]>([]);
+  const [expiresAt, setExpiresAt] = useState("");
+
+  function addRecipient() {
+    const email = recipientInput.trim();
+    if (email && !recipientEmails.includes(email)) {
+      setRecipientEmails((prev) => [...prev, email]);
+      setRecipientInput("");
+    }
+  }
+
+  function removeRecipient(email: string) {
+    setRecipientEmails((prev) => prev.filter((e) => e !== email));
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    // Submission will be wired to POST /api/invites once backend is ready.
+  }
+
+  return (
+    <PageShell maxWidth={640}>
+      <Card>
+        <div style={headerAccent} />
+        <p style={tagline}>Staff Portal</p>
+        <h1 style={heading}>Create Assessment Invite</h1>
+        <p style={subtitle}>
+          Send a secure pre-test link to a student. The invite will include the
+          selected assessments and expire on the date you choose.
+        </p>
+      </Card>
+
+      <Card>
+        <form onSubmit={handleSubmit}>
+          <h2 style={sectionLabel}>Student details</h2>
+          <TextInput
+            label="Student name"
+            placeholder="e.g. Alex Chen"
+            value={studentName}
+            onChange={(e) => setStudentName(e.target.value)}
+            required
+          />
+          <TextInput
+            label="Parent email"
+            type="email"
+            placeholder="parent@example.com"
+            value={parentEmail}
+            onChange={(e) => setParentEmail(e.target.value)}
+            required
+          />
+
+          <hr style={divider} />
+
+          <h2 style={sectionLabel}>Additional recipients</h2>
+          <div style={{ display: "flex", gap: 10, alignItems: "flex-end" }}>
+            <div style={{ flex: 1 }}>
+              <TextInput
+                label="Recipient email"
+                type="email"
+                placeholder="colleague@school.edu"
+                value={recipientInput}
+                onChange={(e) => setRecipientInput(e.target.value)}
+                hint="Optional — add anyone who should receive the report."
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    addRecipient();
+                  }
+                }}
+              />
+            </div>
+            <div style={{ marginBottom: 20 }}>
+              <Button type="button" variant="secondary" onClick={addRecipient}>
+                Add
+              </Button>
+            </div>
+          </div>
+          {recipientEmails.length > 0 && (
+            <div style={chipRow}>
+              {recipientEmails.map((email) => (
+                <span key={email} style={chip}>
+                  {email}
+                  <button
+                    type="button"
+                    style={removeBtn}
+                    onClick={() => removeRecipient(email)}
+                    aria-label={`Remove ${email}`}
+                  >
+                    &times;
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+
+          <hr style={divider} />
+
+          <h2 style={sectionLabel}>Scheduling</h2>
+          <TextInput
+            label="Invite expires"
+            type="date"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            hint="The student will not be able to start the assessment after this date."
+            required
+          />
+
+          <hr style={divider} />
+
+          <h2 style={sectionLabel}>Assessments</h2>
+          <p
+            style={{
+              margin: "0 0 16px",
+              fontSize: 14,
+              color: "#78716c",
+              lineHeight: 1.5,
+            }}
+          >
+            Assessment selection will be available once the content catalogue is
+            populated. For now, invites will be created without specific
+            assessment bindings.
+          </p>
+
+          <div style={{ display: "flex", gap: 12, marginTop: 8 }}>
+            <Button type="submit">Create invite</Button>
+            <Button type="button" variant="secondary">
+              Save draft
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </PageShell>
+  );
+}

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -1,0 +1,60 @@
+import type { ButtonHTMLAttributes, CSSProperties } from "react";
+
+type ButtonVariant = "primary" | "secondary";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  fullWidth?: boolean;
+}
+
+const baseStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 8,
+  padding: "12px 28px",
+  borderRadius: 14,
+  fontSize: 15,
+  fontWeight: 600,
+  fontFamily: "inherit",
+  cursor: "pointer",
+  transition: "background 0.15s, box-shadow 0.15s, opacity 0.15s",
+  border: "none",
+  lineHeight: 1.4,
+};
+
+const variantStyles: Record<ButtonVariant, CSSProperties> = {
+  primary: {
+    background: "linear-gradient(135deg, #b45309, #92400e)",
+    color: "#fff",
+    boxShadow: "0 4px 14px rgba(180, 83, 9, 0.3)",
+  },
+  secondary: {
+    background: "rgba(255,255,255,0.85)",
+    color: "#92400e",
+    border: "1.5px solid rgba(146, 64, 14, 0.25)",
+    boxShadow: "0 2px 8px rgba(15, 23, 42, 0.06)",
+  },
+};
+
+export function Button({
+  variant = "primary",
+  fullWidth,
+  style,
+  disabled,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      style={{
+        ...baseStyle,
+        ...variantStyles[variant],
+        ...(fullWidth ? { width: "100%" } : {}),
+        ...(disabled ? { opacity: 0.55, cursor: "not-allowed" } : {}),
+        ...style,
+      }}
+      disabled={disabled}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/card.tsx
+++ b/packages/ui/src/card.tsx
@@ -1,0 +1,22 @@
+import type { CSSProperties, ReactNode } from "react";
+
+interface CardProps {
+  children: ReactNode;
+  accent?: string;
+  style?: CSSProperties;
+}
+
+export function Card({ children, accent, style }: CardProps) {
+  const cardStyle: CSSProperties = {
+    padding: 32,
+    borderRadius: 24,
+    background: "rgba(255,255,255,0.92)",
+    border: accent
+      ? `1px solid ${accent}30`
+      : "1px solid rgba(148,163,184,0.25)",
+    boxShadow: "0 18px 44px rgba(15,23,42,0.08)",
+    ...style,
+  };
+
+  return <div style={cardStyle}>{children}</div>;
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -42,3 +42,8 @@ export function SectionCard({
     </section>
   );
 }
+
+export { Button } from "./button.js";
+export { TextInput } from "./text-input.js";
+export { PageShell } from "./page-shell.js";
+export { Card } from "./card.js";

--- a/packages/ui/src/page-shell.tsx
+++ b/packages/ui/src/page-shell.tsx
@@ -1,0 +1,35 @@
+import type { CSSProperties, ReactNode } from "react";
+
+interface PageShellProps {
+  children: ReactNode;
+  maxWidth?: number;
+  gradient?: string;
+}
+
+const defaultGradient =
+  "radial-gradient(circle at top left, rgba(229, 176, 104, 0.35), transparent 32%), linear-gradient(180deg, #fff7ed 0%, #f5f3ff 100%)";
+
+export function PageShell({
+  children,
+  maxWidth = 720,
+  gradient = defaultGradient,
+}: PageShellProps) {
+  const outerStyle: CSSProperties = {
+    minHeight: "100vh",
+    padding: "48px 24px 80px",
+    background: gradient,
+  };
+
+  const innerStyle: CSSProperties = {
+    maxWidth,
+    margin: "0 auto",
+    display: "grid",
+    gap: 24,
+  };
+
+  return (
+    <main style={outerStyle}>
+      <section style={innerStyle}>{children}</section>
+    </main>
+  );
+}

--- a/packages/ui/src/text-input.tsx
+++ b/packages/ui/src/text-input.tsx
@@ -1,0 +1,82 @@
+import type { CSSProperties, InputHTMLAttributes } from "react";
+
+interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  hint?: string;
+  error?: string;
+}
+
+const labelStyle: CSSProperties = {
+  display: "block",
+  marginBottom: 6,
+  fontSize: 13,
+  fontWeight: 600,
+  color: "#44403c",
+  letterSpacing: "0.02em",
+};
+
+const inputStyle: CSSProperties = {
+  display: "block",
+  width: "100%",
+  padding: "11px 14px",
+  borderRadius: 12,
+  border: "1.5px solid rgba(148, 163, 184, 0.35)",
+  background: "rgba(255,255,255,0.95)",
+  fontSize: 15,
+  fontFamily: "inherit",
+  color: "#1f2937",
+  outline: "none",
+  transition: "border-color 0.15s, box-shadow 0.15s",
+  boxSizing: "border-box",
+};
+
+const hintStyle: CSSProperties = {
+  margin: "4px 0 0",
+  fontSize: 12,
+  color: "#78716c",
+  lineHeight: 1.4,
+};
+
+const errorStyle: CSSProperties = {
+  margin: "4px 0 0",
+  fontSize: 12,
+  color: "#dc2626",
+  lineHeight: 1.4,
+};
+
+export function TextInput({
+  label,
+  hint,
+  error,
+  id,
+  style,
+  ...props
+}: TextInputProps) {
+  const fieldId = id ?? label.toLowerCase().replace(/\s+/g, "-");
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <label htmlFor={fieldId} style={labelStyle}>
+        {label}
+      </label>
+      <input
+        id={fieldId}
+        style={{
+          ...inputStyle,
+          ...(error
+            ? {
+                borderColor: "#dc2626",
+                boxShadow: "0 0 0 2px rgba(220,38,38,0.1)",
+              }
+            : {}),
+          ...style,
+        }}
+        {...props}
+      />
+      {error ? (
+        <p style={errorStyle}>{error}</p>
+      ) : hint ? (
+        <p style={hintStyle}>{hint}</p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #2

## Summary

- Adds `/staff/invites/new` as the staff-facing invite creation shell with student details, optional recipients, expiry date, and an assessment placeholder section
- Adds `/s/[token]` as the student landing page shell that explains the pre-test flow and provides a begin-assessment CTA
- Adds shared UI primitives in `@begifted/ui` needed by both new routes: `Button`, `TextInput`, `Card`, and `PageShell`

## Routes Added

| Route | Purpose |
|-------|---------|
| `apps/web/app/staff/invites/new/page.tsx` | Staff invite creation form shell |
| `apps/web/app/s/[token]/page.tsx` | Student assessment landing shell |

## Components Added Or Changed

| File | Change |
|------|--------|
| `packages/ui/src/button.tsx` | New shared button primitive |
| `packages/ui/src/text-input.tsx` | New labeled input primitive with hint/error support |
| `packages/ui/src/card.tsx` | New accent-border card container |
| `packages/ui/src/page-shell.tsx` | New page layout wrapper with gradient background |
| `packages/ui/src/index.tsx` | Re-exports the new primitives |

## API Assumptions

- `POST /api/invites` will eventually accept `{ studentName, parentEmail, recipientEmails, assessmentVersionIds, expiresAt }`
- `GET /api/public/invites/:token` will eventually validate the invite token and supply student-safe invite metadata
- assessment selection remains a placeholder until the content catalogue is available

## Test Plan

- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Open Risks

- assessment selection is not wired until the content catalogue exists
- token validation and expired/invalid-state handling are still stubbed on `/s/[token]`

## Handoff

- Issue ID: `#2`
- Branch: `codex/feat/2-invite-shell`
- Objective completed: shell-only staff invite page and student landing route
- Files changed: `apps/web/app/staff/invites/new/page.tsx`, `apps/web/app/s/[token]/page.tsx`, `packages/ui/src/button.tsx`, `packages/ui/src/text-input.tsx`, `packages/ui/src/card.tsx`, `packages/ui/src/page-shell.tsx`, `packages/ui/src/index.tsx`
- Checks run: `npm run lint`, `npm run typecheck`, `npm run build`
- Unresolved risks: no live invite API or token validation yet
- Next recommended task: connect the invite form to `POST /api/invites` and add token-backed invite lookup for `/s/[token]`
- Safe to merge: `yes`
