### PR TITLE
feat: add grading shell and review queue endpoints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "lint": "biome check src test",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",
-    "test:integration": "vitest run test/health.test.ts"
+    "test:integration": "npm run build --workspace @begifted/core && vitest run test/health.test.ts"
   },
   "dependencies": {
     "@begifted/core": "*",

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,9 +1,27 @@
 import Fastify from "fastify";
 
-import { evaluateObjectiveAnswer } from "@begifted/core";
+import {
+  type GradingResultRecord,
+  createReviewResolutionResponse,
+  evaluateObjectiveAnswer,
+  evaluateSessionAnswers,
+  isObjectiveEvaluationRequest,
+  isReviewResolutionRequest,
+  isSessionEvaluationRequest,
+  listReviewQueue,
+  resolveReview,
+} from "@begifted/core";
+
+function createInvalidRequestResponse(message: string) {
+  return {
+    error: "invalid_request",
+    message,
+  };
+}
 
 export function buildServer() {
   const server = Fastify({ logger: false });
+  const gradingResults = new Map<string, GradingResultRecord>();
 
   server.get("/health", async () => ({
     status: "ok",
@@ -11,16 +29,76 @@ export function buildServer() {
     timestamp: new Date().toISOString(),
   }));
 
-  server.post("/api/grading/evaluate", async (request) => {
-    const payload = request.body as {
-      answer: string | number | Array<string | number>;
-      acceptedAnswers: string[];
-    };
+  server.post("/api/grading/evaluate", async (request, reply) => {
+    const payload = request.body;
+
+    if (isSessionEvaluationRequest(payload)) {
+      const result = evaluateSessionAnswers(payload);
+
+      for (const gradingResult of result.gradingResults) {
+        gradingResults.set(gradingResult.id, gradingResult);
+      }
+
+      return result;
+    }
+
+    if (!isObjectiveEvaluationRequest(payload)) {
+      reply.code(400);
+
+      return createInvalidRequestResponse(
+        "Expected either an objective evaluation payload or a session grading payload.",
+      );
+    }
 
     return {
       result: evaluateObjectiveAnswer(payload.answer, payload.acceptedAnswers),
     };
   });
+
+  server.get("/api/review-queue", async () => {
+    return listReviewQueue(gradingResults.values());
+  });
+
+  server.post(
+    "/api/review-queue/:gradingResultId/resolve",
+    async (request, reply) => {
+      const { gradingResultId } = request.params as { gradingResultId: string };
+      const payload = request.body;
+      const gradingResult = gradingResults.get(gradingResultId);
+
+      if (!gradingResult) {
+        reply.code(404);
+
+        return {
+          error: "not_found",
+          message: "Grading result was not found.",
+        };
+      }
+
+      if (!isReviewResolutionRequest(payload)) {
+        reply.code(400);
+
+        return createInvalidRequestResponse(
+          "Expected reviewedBy, scoreAwarded, and rationale for review resolution.",
+        );
+      }
+
+      if (!gradingResult.requiresReview) {
+        reply.code(409);
+
+        return {
+          error: "review_not_required",
+          message: "Grading result is not pending review.",
+        };
+      }
+
+      const resolvedResult = resolveReview(gradingResult, payload);
+
+      gradingResults.set(resolvedResult.id, resolvedResult);
+
+      return createReviewResolutionResponse(resolvedResult);
+    },
+  );
 
   return server;
 }

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -33,4 +33,380 @@ describe("api health and grading", () => {
 
     await server.close();
   });
+
+  it("rejects invalid grading payloads", async () => {
+    const server = buildServer();
+    const response = await server.inject({
+      method: "POST",
+      url: "/api/grading/evaluate",
+      payload: {
+        sessionId: "session-invalid",
+        answers: "not-an-array",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "invalid_request",
+      message:
+        "Expected either an objective evaluation payload or a session grading payload.",
+    });
+
+    await server.close();
+  });
+
+  it("seeds grading results and review-queue entries for a submitted session", async () => {
+    const server = buildServer();
+    const response = await server.inject({
+      method: "POST",
+      url: "/api/grading/evaluate",
+      payload: {
+        sessionId: "session-123",
+        submittedAt: "2026-03-18T09:30:00.000Z",
+        answers: [
+          {
+            submissionAnswerId: "answer-1",
+            questionId: "question-1",
+            gradingMode: "deterministic",
+            answer: " B ",
+            acceptedAnswers: ["b"],
+            maxScore: 1,
+          },
+          {
+            submissionAnswerId: "answer-2",
+            questionId: "question-2",
+            gradingMode: "manual-review-required",
+            answer: "Photosynthesis converts light into energy.",
+            maxScore: 4,
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      sessionId: "session-123",
+      summary: {
+        totalAnswers: 2,
+        autoScoredCount: 1,
+        reviewRequiredCount: 1,
+      },
+      gradingResults: [
+        {
+          id: "session-123:answer-1",
+          questionId: "question-1",
+          scoreAwarded: 1,
+          maxScore: 1,
+          requiresReview: false,
+          resolution: "confirmed",
+        },
+        {
+          id: "session-123:answer-2",
+          questionId: "question-2",
+          scoreAwarded: 0,
+          maxScore: 4,
+          requiresReview: true,
+          resolution: "pending",
+        },
+      ],
+      events: [
+        {
+          eventType: "grading.finished",
+          sessionId: "session-123",
+        },
+        {
+          eventType: "review.required",
+          sessionId: "session-123",
+          gradingResultId: "session-123:answer-2",
+        },
+      ],
+    });
+
+    const reviewQueueResponse = await server.inject({
+      method: "GET",
+      url: "/api/review-queue",
+    });
+
+    expect(reviewQueueResponse.statusCode).toBe(200);
+    expect(reviewQueueResponse.json()).toMatchObject({
+      total: 1,
+      items: [
+        {
+          id: "session-123:answer-2",
+          sessionId: "session-123",
+          submissionAnswerId: "answer-2",
+          questionId: "question-2",
+          requiresReview: true,
+          submittedAt: "2026-03-18T09:30:00.000Z",
+        },
+      ],
+    });
+
+    await server.close();
+  });
+
+  it("lists pending review items oldest first across seeded sessions", async () => {
+    const server = buildServer();
+
+    await server.inject({
+      method: "POST",
+      url: "/api/grading/evaluate",
+      payload: {
+        sessionId: "session-earlier",
+        submittedAt: "2026-03-18T09:15:00.000Z",
+        answers: [
+          {
+            submissionAnswerId: "answer-earlier",
+            questionId: "question-earlier",
+            gradingMode: "manual-review-required",
+            answer: "Earlier essay",
+            maxScore: 5,
+          },
+        ],
+      },
+    });
+
+    await server.inject({
+      method: "POST",
+      url: "/api/grading/evaluate",
+      payload: {
+        sessionId: "session-later",
+        submittedAt: "2026-03-18T09:50:00.000Z",
+        answers: [
+          {
+            submissionAnswerId: "answer-later",
+            questionId: "question-later",
+            gradingMode: "manual-review-required",
+            answer: "Later essay",
+            maxScore: 5,
+          },
+        ],
+      },
+    });
+
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/review-queue",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      total: 2,
+      items: [
+        {
+          id: "session-earlier:answer-earlier",
+          submittedAt: "2026-03-18T09:15:00.000Z",
+        },
+        {
+          id: "session-later:answer-later",
+          submittedAt: "2026-03-18T09:50:00.000Z",
+        },
+      ],
+    });
+
+    await server.close();
+  });
+
+  it("routes deterministic answers without answer keys into the review queue", async () => {
+    const server = buildServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/api/grading/evaluate",
+      payload: {
+        sessionId: "session-789",
+        submittedAt: "2026-03-18T09:45:00.000Z",
+        answers: [
+          {
+            submissionAnswerId: "answer-missing-key",
+            questionId: "question-missing-key",
+            gradingMode: "deterministic",
+            answer: "42",
+            maxScore: 2,
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      sessionId: "session-789",
+      summary: {
+        totalAnswers: 1,
+        autoScoredCount: 0,
+        reviewRequiredCount: 1,
+      },
+      gradingResults: [
+        {
+          id: "session-789:answer-missing-key",
+          requiresReview: true,
+          rationale:
+            "Accepted answers were not provided for deterministic grading.",
+          resolution: "pending",
+        },
+      ],
+      events: [
+        {
+          eventType: "grading.finished",
+          sessionId: "session-789",
+        },
+        {
+          eventType: "review.required",
+          gradingResultId: "session-789:answer-missing-key",
+          sessionId: "session-789",
+        },
+      ],
+    });
+
+    const reviewQueueResponse = await server.inject({
+      method: "GET",
+      url: "/api/review-queue",
+    });
+
+    expect(reviewQueueResponse.statusCode).toBe(200);
+    expect(reviewQueueResponse.json()).toMatchObject({
+      total: 1,
+      items: [
+        {
+          id: "session-789:answer-missing-key",
+          questionId: "question-missing-key",
+          submittedAt: "2026-03-18T09:45:00.000Z",
+        },
+      ],
+    });
+
+    await server.close();
+  });
+
+  it("resolves review-queue items and removes them from the queue", async () => {
+    const server = buildServer();
+
+    await server.inject({
+      method: "POST",
+      url: "/api/grading/evaluate",
+      payload: {
+        sessionId: "session-456",
+        answers: [
+          {
+            submissionAnswerId: "answer-essay",
+            questionId: "question-essay",
+            gradingMode: "manual-review-required",
+            answer: "A paragraph response",
+            maxScore: 6,
+          },
+        ],
+      },
+    });
+
+    const resolutionResponse = await server.inject({
+      method: "POST",
+      url: "/api/review-queue/session-456:answer-essay/resolve",
+      payload: {
+        reviewedBy: "staff-42",
+        scoreAwarded: 5,
+        rationale: "Rubric fit after manual review.",
+      },
+    });
+
+    expect(resolutionResponse.statusCode).toBe(200);
+    expect(resolutionResponse.json()).toMatchObject({
+      gradingResult: {
+        id: "session-456:answer-essay",
+        scoreAwarded: 5,
+        requiresReview: false,
+        reviewedBy: "staff-42",
+        rationale: "Rubric fit after manual review.",
+        resolution: "score-overridden",
+      },
+    });
+
+    const reviewQueueResponse = await server.inject({
+      method: "GET",
+      url: "/api/review-queue",
+    });
+
+    expect(reviewQueueResponse.statusCode).toBe(200);
+    expect(reviewQueueResponse.json()).toMatchObject({
+      total: 0,
+      items: [],
+    });
+
+    const secondResolutionAttempt = await server.inject({
+      method: "POST",
+      url: "/api/review-queue/session-456:answer-essay/resolve",
+      payload: {
+        reviewedBy: "staff-42",
+        scoreAwarded: 5,
+        rationale: "Already resolved.",
+      },
+    });
+
+    expect(secondResolutionAttempt.statusCode).toBe(409);
+    expect(secondResolutionAttempt.json()).toMatchObject({
+      error: "review_not_required",
+    });
+
+    await server.close();
+  });
+
+  it("rejects invalid review-resolution payloads", async () => {
+    const server = buildServer();
+
+    await server.inject({
+      method: "POST",
+      url: "/api/grading/evaluate",
+      payload: {
+        sessionId: "session-review-invalid",
+        answers: [
+          {
+            submissionAnswerId: "answer-review-invalid",
+            questionId: "question-review-invalid",
+            gradingMode: "manual-review-required",
+            answer: "Needs manual review",
+            maxScore: 3,
+          },
+        ],
+      },
+    });
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/api/review-queue/session-review-invalid:answer-review-invalid/resolve",
+      payload: {
+        reviewedBy: "staff-42",
+        rationale: "Missing score awarded.",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "invalid_request",
+      message:
+        "Expected reviewedBy, scoreAwarded, and rationale for review resolution.",
+    });
+
+    await server.close();
+  });
+
+  it("returns 404 when resolving an unknown review item", async () => {
+    const server = buildServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/api/review-queue/session-missing:answer-missing/resolve",
+      payload: {
+        reviewedBy: "staff-42",
+        scoreAwarded: 1,
+        rationale: "Attempted review on missing item.",
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({
+      error: "not_found",
+      message: "Grading result was not found.",
+    });
+
+    await server.close();
+  });
 });

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -45,13 +45,52 @@ Locks the session and emits `submission.completed`.
 
 ## Staff endpoints
 
+### `POST /api/grading/evaluate`
+
+Seeds grading results for a submitted session and emits shell grading events.
+
+Request fields:
+
+- `sessionId`
+- `submittedAt` optional
+- `answers[]`
+- `answers[].submissionAnswerId`
+- `answers[].questionId`
+- `answers[].gradingMode`
+- `answers[].answer`
+- `answers[].acceptedAnswers` optional for deterministic items
+- `answers[].maxScore`
+
+Response fields:
+
+- `sessionId`
+- `submittedAt`
+- `gradingResults`
+- `summary`
+- `events`
+
 ### `GET /api/review-queue`
 
 Returns submissions requiring review.
 
+Response fields:
+
+- `items`
+- `total`
+
 ### `POST /api/review-queue/:gradingResultId/resolve`
 
 Stores a review decision or score override.
+
+Request fields:
+
+- `reviewedBy`
+- `scoreAwarded`
+- `rationale`
+
+Response fields:
+
+- `gradingResult`
 
 ### `POST /api/reports/:sessionId/generate`
 
@@ -89,4 +128,3 @@ Each event payload must include:
 - public token endpoints return `404` or `410` for invalid or expired links
 - submission endpoints reject writes after final submit
 - report send endpoints reject when unresolved reviews remain
-

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -41,3 +41,9 @@
 - Status: accepted
 - Decision: use machine-evaluated governance rules to auto-approve eligible PRs, detect shared-contract and shared-scope changes, and create releases from `main`
 - Rationale: removes manual orchestration bottlenecks while keeping risky changes explicit and auditable
+
+## ADR-008: Shared grading shell contracts
+
+- Status: accepted
+- Decision: keep the grading seed and review-resolution payload shapes in `packages/core`, while the API shell uses in-memory storage until persistence and job orchestration land
+- Rationale: allows route consumers to integrate against one shared contract source without prematurely introducing database or workflow infrastructure

--- a/packages/core/src/grading-shell.ts
+++ b/packages/core/src/grading-shell.ts
@@ -1,0 +1,358 @@
+import { evaluateObjectiveAnswer } from "./grading.js";
+
+export type ScalarAnswer = string | number;
+export type SubmittedAnswer = ScalarAnswer | Array<ScalarAnswer>;
+export type GradingMode = "deterministic" | "manual-review-required";
+export type ReviewResolution = "pending" | "confirmed" | "score-overridden";
+
+export interface ObjectiveEvaluationRequest {
+  answer: SubmittedAnswer;
+  acceptedAnswers: string[];
+}
+
+export interface SessionAnswerInput {
+  submissionAnswerId: string;
+  questionId: string;
+  gradingMode: GradingMode;
+  answer: SubmittedAnswer;
+  acceptedAnswers?: string[];
+  maxScore: number;
+}
+
+export interface SessionEvaluationRequest {
+  sessionId: string;
+  submittedAt?: string;
+  answers: SessionAnswerInput[];
+}
+
+export interface ReviewResolutionRequest {
+  reviewedBy: string;
+  scoreAwarded: number;
+  rationale: string;
+}
+
+export interface GradingEvent {
+  eventId: string;
+  eventType: "grading.finished" | "review.required";
+  occurredAt: string;
+  sessionId: string;
+  actorType: "system";
+  source: "api";
+  gradingResultId?: string;
+}
+
+export interface GradingResultRecord {
+  id: string;
+  sessionId: string;
+  submissionAnswerId: string;
+  questionId: string;
+  gradingMode: GradingMode;
+  answer: SubmittedAnswer;
+  scoreAwarded: number;
+  maxScore: number;
+  confidence: number;
+  requiresReview: boolean;
+  rationale: string;
+  reviewedBy: string | null;
+  reviewedAt: string | null;
+  submittedAt: string;
+  resolution: ReviewResolution;
+}
+
+export interface SessionGradingSummary {
+  totalAnswers: number;
+  autoScoredCount: number;
+  reviewRequiredCount: number;
+}
+
+export interface SessionGradingResponse {
+  sessionId: string;
+  submittedAt: string;
+  gradingResults: GradingResultRecord[];
+  summary: SessionGradingSummary;
+  events: GradingEvent[];
+}
+
+export interface ReviewQueueResponse {
+  items: GradingResultRecord[];
+  total: number;
+}
+
+export interface ReviewResolutionResponse {
+  gradingResult: GradingResultRecord;
+}
+
+function isScalarAnswer(value: unknown): value is ScalarAnswer {
+  return typeof value === "string" || typeof value === "number";
+}
+
+function isSubmittedAnswer(value: unknown): value is SubmittedAnswer {
+  return (
+    isScalarAnswer(value) ||
+    (Array.isArray(value) && value.every((item) => isScalarAnswer(item)))
+  );
+}
+
+function isGradingMode(value: unknown): value is GradingMode {
+  return value === "deterministic" || value === "manual-review-required";
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function isSessionAnswerInput(value: unknown): value is SessionAnswerInput {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "submissionAnswerId" in value &&
+    typeof value.submissionAnswerId === "string" &&
+    "questionId" in value &&
+    typeof value.questionId === "string" &&
+    "gradingMode" in value &&
+    isGradingMode(value.gradingMode) &&
+    "answer" in value &&
+    isSubmittedAnswer(value.answer) &&
+    "maxScore" in value &&
+    isFiniteNumber(value.maxScore) &&
+    (!("acceptedAnswers" in value) ||
+      value.acceptedAnswers === undefined ||
+      isStringArray(value.acceptedAnswers))
+  );
+}
+
+export function isObjectiveEvaluationRequest(
+  payload: unknown,
+): payload is ObjectiveEvaluationRequest {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "answer" in payload &&
+    isSubmittedAnswer(payload.answer) &&
+    "acceptedAnswers" in payload &&
+    isStringArray(payload.acceptedAnswers)
+  );
+}
+
+export function isSessionEvaluationRequest(
+  payload: unknown,
+): payload is SessionEvaluationRequest {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "sessionId" in payload &&
+    typeof payload.sessionId === "string" &&
+    (!("submittedAt" in payload) ||
+      payload.submittedAt === undefined ||
+      typeof payload.submittedAt === "string") &&
+    "answers" in payload &&
+    Array.isArray(payload.answers) &&
+    payload.answers.every((answer) => isSessionAnswerInput(answer))
+  );
+}
+
+export function isReviewResolutionRequest(
+  payload: unknown,
+): payload is ReviewResolutionRequest {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "reviewedBy" in payload &&
+    typeof payload.reviewedBy === "string" &&
+    "scoreAwarded" in payload &&
+    isFiniteNumber(payload.scoreAwarded) &&
+    "rationale" in payload &&
+    typeof payload.rationale === "string"
+  );
+}
+
+export function createGradingResultId(
+  sessionId: string,
+  submissionAnswerId: string,
+) {
+  return `${sessionId}:${submissionAnswerId}`;
+}
+
+function createEvent(
+  eventType: GradingEvent["eventType"],
+  sessionId: string,
+  gradingResultId?: string,
+): GradingEvent {
+  const occurredAt = new Date().toISOString();
+
+  return {
+    eventId: `${eventType}:${gradingResultId ?? sessionId}:${occurredAt}`,
+    eventType,
+    occurredAt,
+    sessionId,
+    actorType: "system",
+    source: "api",
+    gradingResultId,
+  };
+}
+
+function evaluateSessionAnswer(
+  sessionId: string,
+  submittedAt: string,
+  answer: SessionAnswerInput,
+): { gradingResult: GradingResultRecord; events: GradingEvent[] } {
+  const gradingResultId = createGradingResultId(
+    sessionId,
+    answer.submissionAnswerId,
+  );
+
+  if (answer.gradingMode === "manual-review-required") {
+    return {
+      gradingResult: {
+        id: gradingResultId,
+        sessionId,
+        submissionAnswerId: answer.submissionAnswerId,
+        questionId: answer.questionId,
+        gradingMode: answer.gradingMode,
+        answer: answer.answer,
+        scoreAwarded: 0,
+        maxScore: answer.maxScore,
+        confidence: 0,
+        requiresReview: true,
+        rationale: "Manual review required for this grading mode.",
+        reviewedBy: null,
+        reviewedAt: null,
+        submittedAt,
+        resolution: "pending",
+      },
+      events: [createEvent("review.required", sessionId, gradingResultId)],
+    };
+  }
+
+  if (!answer.acceptedAnswers || answer.acceptedAnswers.length === 0) {
+    return {
+      gradingResult: {
+        id: gradingResultId,
+        sessionId,
+        submissionAnswerId: answer.submissionAnswerId,
+        questionId: answer.questionId,
+        gradingMode: answer.gradingMode,
+        answer: answer.answer,
+        scoreAwarded: 0,
+        maxScore: answer.maxScore,
+        confidence: 0,
+        requiresReview: true,
+        rationale:
+          "Accepted answers were not provided for deterministic grading.",
+        reviewedBy: null,
+        reviewedAt: null,
+        submittedAt,
+        resolution: "pending",
+      },
+      events: [createEvent("review.required", sessionId, gradingResultId)],
+    };
+  }
+
+  const evaluation = evaluateObjectiveAnswer(
+    answer.answer,
+    answer.acceptedAnswers,
+  );
+  const scoreAwarded = evaluation.isCorrect ? answer.maxScore : 0;
+
+  return {
+    gradingResult: {
+      id: gradingResultId,
+      sessionId,
+      submissionAnswerId: answer.submissionAnswerId,
+      questionId: answer.questionId,
+      gradingMode: answer.gradingMode,
+      answer: answer.answer,
+      scoreAwarded,
+      maxScore: answer.maxScore,
+      confidence: evaluation.isCorrect ? 1 : 0.25,
+      requiresReview: false,
+      rationale: evaluation.isCorrect
+        ? "Deterministic evaluation matched the accepted answers."
+        : "Deterministic evaluation did not match the accepted answers.",
+      reviewedBy: null,
+      reviewedAt: null,
+      submittedAt,
+      resolution: "confirmed",
+    },
+    events: [],
+  };
+}
+
+export function evaluateSessionAnswers(
+  payload: SessionEvaluationRequest,
+): SessionGradingResponse {
+  const submittedAt = payload.submittedAt ?? new Date().toISOString();
+  const gradingResultsForSession = payload.answers.map((answer) =>
+    evaluateSessionAnswer(payload.sessionId, submittedAt, answer),
+  );
+  const gradingResults = gradingResultsForSession.map(
+    ({ gradingResult }) => gradingResult,
+  );
+  const events = gradingResultsForSession.flatMap(({ events }) => events);
+
+  events.unshift(createEvent("grading.finished", payload.sessionId));
+
+  return {
+    sessionId: payload.sessionId,
+    submittedAt,
+    gradingResults,
+    summary: {
+      totalAnswers: gradingResults.length,
+      autoScoredCount: gradingResults.filter((result) => !result.requiresReview)
+        .length,
+      reviewRequiredCount: gradingResults.filter(
+        (result) => result.requiresReview,
+      ).length,
+    },
+    events,
+  };
+}
+
+export function listReviewQueue(
+  gradingResults: Iterable<GradingResultRecord>,
+): ReviewQueueResponse {
+  const items = Array.from(gradingResults)
+    .filter((result) => result.requiresReview)
+    .sort((left, right) => left.submittedAt.localeCompare(right.submittedAt));
+
+  return {
+    items,
+    total: items.length,
+  };
+}
+
+export function resolveReview(
+  gradingResult: GradingResultRecord,
+  payload: ReviewResolutionRequest,
+): GradingResultRecord {
+  const reviewedAt = new Date().toISOString();
+  const resolution =
+    payload.scoreAwarded === gradingResult.scoreAwarded
+      ? "confirmed"
+      : "score-overridden";
+
+  return {
+    ...gradingResult,
+    scoreAwarded: payload.scoreAwarded,
+    rationale: payload.rationale,
+    reviewedBy: payload.reviewedBy,
+    reviewedAt,
+    requiresReview: false,
+    confidence: 1,
+    resolution,
+  };
+}
+
+export function createReviewResolutionResponse(
+  gradingResult: GradingResultRecord,
+): ReviewResolutionResponse {
+  return {
+    gradingResult,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./contracts.js";
 export * from "./grading.js";
+export * from "./grading-shell.js";


### PR DESCRIPTION
Closes #3

## Summary

- extends `POST /api/grading/evaluate` to accept submitted-session grading payloads in addition to simple objective checks
- adds in-memory review queue routes for listing pending reviews and resolving manual overrides
- introduces shared grading-shell contracts and helpers in `@begifted/core` so API consumers can integrate against one source of truth
- documents the shell contracts and records the shared-contract decision in ADR-008

## Routes Added Or Changed

| Route | Purpose |
|-------|---------|
| `POST /api/grading/evaluate` | Seed grading results and grading events for a submitted session |
| `GET /api/review-queue` | List pending review items oldest first |
| `POST /api/review-queue/:gradingResultId/resolve` | Resolve a queued review decision |

## Core Contract Surface

| File | Change |
|------|--------|
| `packages/core/src/grading-shell.ts` | New request/response types and shell grading helpers |
| `packages/core/src/index.ts` | Re-exports grading shell contracts |
| `docs/API_CONTRACTS.md` | Documents session grading and review queue payloads |
| `docs/DECISIONS.md` | Adds ADR-008 for shared grading shell contracts |

## Test Plan

- `npm run lint`
- `npm run typecheck`
- `npm run test:integration`

## Open Risks

- grading results are stored in-memory only and will reset between process restarts
- report generation and submission-complete event wiring are still downstream tasks
- no persistence or background job orchestration exists yet for grading events

## Handoff

- Issue ID: `#3`
- Branch: `codex/feat/3-grading-shell`
- Objective completed: grading shell routes, review queue shell, and shared grading contracts
- Files changed: `apps/api/src/server.ts`, `apps/api/test/health.test.ts`, `packages/core/src/grading-shell.ts`, `packages/core/src/index.ts`, `docs/API_CONTRACTS.md`, `docs/DECISIONS.md`
- Checks run: `npm run lint`, `npm run typecheck`, `npm run test:integration`
- Unresolved risks: in-memory storage only; no workflow/event persistence yet
- Next recommended task: replace in-memory grading storage with database-backed persistence and connect submission completion to grading job orchestration
- Safe to merge: `yes`
