### PR TITLE
feat(wise): add shadow sandbox integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Supported agent runtimes include Codex and Claude Code, as long as each active s
 
 To launch multiple agents automatically from GitHub-ready issues, use the local supervisor described in [docs/ORCHESTRATION.md](./docs/ORCHESTRATION.md).
 
+## Wise shadow safety
+
+- Wise integration is currently sandbox-only
+- all Wise writes are dry-run by default unless `WISE_SANDBOX_ALLOW_MUTATIONS=true`
+- only BeGifted-owned dummy Wise students, courses, and tests may be created or mutated
+- live Wise students, billing, credits, fees, and operational records are out of bounds
+
 ## GitHub setup
 
 Run the bootstrap helper after creating the GitHub repository and authenticating `gh`:

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -5,12 +5,17 @@ import {
   createReviewResolutionResponse,
   evaluateObjectiveAnswer,
   evaluateSessionAnswers,
+  isCreateInviteRequest,
   isObjectiveEvaluationRequest,
   isReviewResolutionRequest,
   isSessionEvaluationRequest,
   listReviewQueue,
   resolveReview,
 } from "@begifted/core";
+import {
+  type WiseSandboxService,
+  createWiseSandboxService,
+} from "./wise-sandbox.js";
 
 function createInvalidRequestResponse(message: string) {
   return {
@@ -19,15 +24,141 @@ function createInvalidRequestResponse(message: string) {
   };
 }
 
-export function buildServer() {
+interface BuildServerOptions {
+  wiseSandbox?: WiseSandboxService;
+}
+
+function createErrorResponse(error: string, message: string) {
+  return { error, message };
+}
+
+export function buildServer(options: BuildServerOptions = {}) {
   const server = Fastify({ logger: false });
   const gradingResults = new Map<string, GradingResultRecord>();
+  const wiseSandbox = options.wiseSandbox ?? createWiseSandboxService();
+
+  server.addHook("onRequest", async (request, reply) => {
+    reply.header("Access-Control-Allow-Origin", "*");
+    reply.header("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+    reply.header("Access-Control-Allow-Headers", "Content-Type");
+
+    if (request.method === "OPTIONS") {
+      return reply.code(204).send();
+    }
+  });
 
   server.get("/health", async () => ({
     status: "ok",
     service: "api",
     timestamp: new Date().toISOString(),
   }));
+
+  server.get("/api/wise/sandbox/account", async () => {
+    return wiseSandbox.getAccountSnapshot();
+  });
+
+  server.get("/api/wise/sandbox/logs", async () => {
+    const items = wiseSandbox.listLogs();
+
+    return {
+      total: items.length,
+      items,
+    };
+  });
+
+  server.post("/api/invites", async (request, reply) => {
+    const payload = request.body;
+
+    if (!isCreateInviteRequest(payload)) {
+      reply.code(400);
+
+      return createInvalidRequestResponse(
+        "Expected studentName, parentEmail, assessmentVersionIds, and expiresAt for a Wise sandbox invite.",
+      );
+    }
+
+    try {
+      return await wiseSandbox.createInvite(payload);
+    } catch (error) {
+      reply.code(400);
+
+      return createErrorResponse(
+        "invalid_request",
+        error instanceof Error
+          ? error.message
+          : "Failed to create Wise sandbox invite.",
+      );
+    }
+  });
+
+  server.get("/api/public/invites/:token", async (request, reply) => {
+    const { token } = request.params as { token: string };
+    const invite = wiseSandbox.getPublicInvite(token);
+
+    if (!invite) {
+      reply.code(404);
+
+      return createErrorResponse("not_found", "Invite was not found.");
+    }
+
+    if (invite.expired) {
+      reply.code(410);
+
+      return createErrorResponse("expired", "Invite has expired.");
+    }
+
+    return invite.invite;
+  });
+
+  server.get("/api/public/invites/:token/launch", async (request, reply) => {
+    const { token } = request.params as { token: string };
+    const invite = wiseSandbox.getPublicInvite(token);
+
+    if (!invite) {
+      reply.code(404);
+
+      return createErrorResponse("not_found", "Invite was not found.");
+    }
+
+    if (invite.expired) {
+      reply.code(410);
+
+      return createErrorResponse("expired", "Invite has expired.");
+    }
+
+    const launchUrl = wiseSandbox.resolveLaunchUrl(token);
+    if (!launchUrl) {
+      reply.code(409);
+
+      return createErrorResponse(
+        "launch_unavailable",
+        "Invite launch target is not available.",
+      );
+    }
+
+    return reply.redirect(launchUrl, 303);
+  });
+
+  server.post(
+    "/api/wise/sandbox/tests/:testId/submissions/sync",
+    async (request, reply) => {
+      const { testId } = request.params as { testId: string };
+
+      try {
+        return await wiseSandbox.syncOwnedTestSubmissions(testId);
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to sync Wise sandbox submissions.";
+        reply.code(
+          /not a BeGifted-owned sandbox entity/i.test(message) ? 403 : 400,
+        );
+
+        return createErrorResponse("sync_blocked", message);
+      }
+    },
+  );
 
   server.post("/api/grading/evaluate", async (request, reply) => {
     const payload = request.body;

--- a/apps/api/src/wise-sandbox.ts
+++ b/apps/api/src/wise-sandbox.ts
@@ -1,0 +1,1383 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  type CreateInviteRequest,
+  type CreateInviteResponse,
+  type PublicInviteLookupResponse,
+  type SessionAnswerInput,
+  type SessionGradingResponse,
+  type WiseAction,
+  type WiseEntityBinding,
+  type WiseReadAction,
+  type WiseSandboxCourse,
+  type WiseSandboxEntityType,
+  type WiseSandboxStudent,
+  type WiseSandboxTest,
+  type WiseSubmissionGradingRecord,
+  type WiseSubmissionSyncResponse,
+  type WiseWriteAction,
+  type WiseWriteLogEntry,
+  createWiseSandboxToken as createCoreInviteToken,
+  createWiseSandboxCourseName,
+  createWiseSandboxExternalRef,
+  createWiseSandboxStudentName,
+  createWiseSandboxTestName,
+  evaluateSessionAnswers,
+  evaluateWiseWriteGuard,
+  wiseAllowedWriteActions,
+  wiseSandboxCoursePrefix,
+  wiseSandboxOwner,
+  wiseSandboxStudentPrefix,
+  wiseSandboxTestPrefix,
+} from "@begifted/core";
+
+type WiseQuestionType =
+  | "MCQ_SINGLE_CORRECT"
+  | "FILL_IN_THE_BLANK"
+  | "INTEGER_ANSWER";
+
+interface AssessmentRecord {
+  id: string;
+  title: string;
+  subject: string;
+  curriculum: string;
+  level: string;
+  durationMinutes: number;
+  questions: Array<{
+    id: string;
+    prompt: string;
+    type: string;
+    marks: number;
+    gradingMode: string;
+    acceptedAnswers: string[];
+  }>;
+}
+
+interface WiseQuestionDraft {
+  questionId: string;
+  marks: number;
+  question_type: WiseQuestionType;
+  text: string;
+  answer: string;
+  options?: Record<string, string>;
+}
+
+interface WisePublishedAssessment {
+  assessmentId: string;
+  assessmentTitle: string;
+  publishedQuestionIds: string[];
+  skippedQuestionIds: string[];
+  questionDrafts: WiseQuestionDraft[];
+}
+
+interface WiseClientConfig {
+  host?: string;
+  examHost?: string;
+  userId?: string;
+  apiKey?: string;
+  instituteId?: string;
+  namespace?: string;
+  userAgent?: string;
+  allowMutations?: boolean;
+  launchUrlTemplate?: string;
+}
+
+interface WiseAccountUser {
+  wiseUserId: string;
+  name: string;
+  namespace: string;
+  email?: string;
+}
+
+interface WiseCourseSection {
+  sectionId: string;
+  name: string;
+}
+
+interface WiseSubmissionRecord {
+  submissionId: string;
+  userName: string;
+  answers: Record<string, string>;
+}
+
+interface WiseTestSubmissionBundle {
+  submissions: WiseSubmissionRecord[];
+}
+
+interface WiseClient {
+  configured: boolean;
+  mode: "dry-run" | "live";
+  namespace: string;
+  launchUrlTemplate?: string;
+  getAccountUser(): Promise<WiseAccountUser>;
+  createStudent(input: {
+    vendorUserId: string;
+    displayName: string;
+    email: string;
+    phoneNumber: string;
+  }): Promise<WiseSandboxStudent>;
+  createCourse(input: {
+    displayName: string;
+    subject: string;
+  }): Promise<WiseSandboxCourse>;
+  assignCourseToStudent(input: {
+    courseId: string;
+    studentId: string;
+  }): Promise<void>;
+  getCourseSections(courseId: string): Promise<WiseCourseSection[]>;
+  createTest(input: {
+    classId: string;
+    displayName: string;
+    sectionId: string;
+  }): Promise<Pick<WiseSandboxTest, "wiseId" | "classId" | "displayName">>;
+  addQuestions(input: {
+    classId: string;
+    testId: string;
+    questions: WiseQuestionDraft[];
+  }): Promise<void>;
+  updateTestSettings(input: {
+    classId: string;
+    testId: string;
+    displayName: string;
+    questionDrafts: WiseQuestionDraft[];
+  }): Promise<void>;
+  publishTest(input: { classId: string; testId: string }): Promise<void>;
+  getTestSubmissions(input: {
+    classId: string;
+    testId: string;
+  }): Promise<WiseTestSubmissionBundle>;
+}
+
+interface WiseSandboxInviteRecord {
+  inviteId: string;
+  token: string;
+  studentName: string;
+  parentEmail: string;
+  recipientEmails: string[];
+  expiresAt: string;
+  assessmentVersionIds: string[];
+  assessmentTitles: string[];
+  deliveryProvider: "wise-sandbox";
+  launchUrl: string | null;
+  dryRun: boolean;
+  wiseStudentId: string;
+  wiseCourseId: string;
+  wiseTestId: string;
+  publishedQuestionIds: string[];
+  skippedQuestionIds: string[];
+}
+
+function toIsoNow() {
+  return new Date().toISOString();
+}
+
+function slugify(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function parseJsonResponse(payload: unknown) {
+  if (typeof payload !== "object" || payload === null) {
+    return {};
+  }
+
+  return payload as Record<string, unknown>;
+}
+
+function extractWiseId(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const record = value as Record<string, unknown>;
+    if (typeof record._id === "string") {
+      return record._id;
+    }
+    if (typeof record.id === "string") {
+      return record.id;
+    }
+    if (typeof record.$oid === "string") {
+      return record.$oid;
+    }
+  }
+
+  return null;
+}
+
+function createSyntheticPhoneNumber(seed: string) {
+  const digits = seed.replace(/\D/g, "").padEnd(10, "0").slice(0, 10);
+
+  return `+1${digits}`;
+}
+
+function createSyntheticStudentIdentity(studentName: string) {
+  const ref = createWiseSandboxExternalRef(studentName);
+  const slug = slugify(studentName) || "student";
+
+  return {
+    externalRef: ref,
+    vendorUserId: ref,
+    email: `${slug}.${ref}@example.invalid`,
+    phoneNumber: createSyntheticPhoneNumber(ref),
+  };
+}
+
+function parseMultipleChoiceDraft(
+  question: AssessmentRecord["questions"][number],
+) {
+  const lines = question.prompt
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const options: Record<string, string> = {};
+  const stem: string[] = [];
+
+  for (const line of lines) {
+    const match = /^([A-D])\.\s*(.+)$/.exec(line);
+    if (match) {
+      const [, optionKey, optionValue] = match;
+      if (!optionKey || !optionValue) {
+        continue;
+      }
+
+      options[optionKey.toLowerCase()] = optionValue;
+      continue;
+    }
+    stem.push(line);
+  }
+
+  const answer = question.acceptedAnswers.find((value) =>
+    /^[A-D]$/i.test(value.trim()),
+  );
+
+  if (Object.keys(options).length < 2 || !answer) {
+    return null;
+  }
+
+  return {
+    questionId: question.id,
+    marks: question.marks,
+    question_type: "MCQ_SINGLE_CORRECT" as const,
+    text: stem.join("\n"),
+    answer: answer.trim().toLowerCase(),
+    options,
+  };
+}
+
+function parseFillBlankDraft(question: AssessmentRecord["questions"][number]) {
+  if (question.acceptedAnswers.length === 0) {
+    return null;
+  }
+
+  return {
+    questionId: question.id,
+    marks: question.marks,
+    question_type: "FILL_IN_THE_BLANK" as const,
+    text: question.prompt,
+    answer: question.acceptedAnswers.join(", "),
+  };
+}
+
+function parseIntegerDraft(question: AssessmentRecord["questions"][number]) {
+  const answer = question.acceptedAnswers.find((value) =>
+    /^\d+$/.test(value.trim()),
+  );
+  if (!answer) {
+    return null;
+  }
+
+  return {
+    questionId: question.id,
+    marks: question.marks,
+    question_type: "INTEGER_ANSWER" as const,
+    text: question.prompt,
+    answer: answer.trim(),
+  };
+}
+
+function buildWisePublishedAssessment(
+  assessment: AssessmentRecord,
+): WisePublishedAssessment {
+  const publishedQuestionIds: string[] = [];
+  const skippedQuestionIds: string[] = [];
+  const questionDrafts: WiseQuestionDraft[] = [];
+
+  for (const question of assessment.questions) {
+    if (question.gradingMode !== "deterministic" || question.marks !== 1) {
+      skippedQuestionIds.push(question.id);
+      continue;
+    }
+
+    let draft: WiseQuestionDraft | null = null;
+
+    if (question.type === "multiple_choice") {
+      draft = parseMultipleChoiceDraft(question);
+    } else if (question.type === "short_text") {
+      draft = parseFillBlankDraft(question);
+    } else if (question.type === "numeric") {
+      draft = parseIntegerDraft(question);
+    }
+
+    if (!draft) {
+      skippedQuestionIds.push(question.id);
+      continue;
+    }
+
+    questionDrafts.push(draft);
+    publishedQuestionIds.push(question.id);
+  }
+
+  return {
+    assessmentId: assessment.id,
+    assessmentTitle: assessment.title,
+    publishedQuestionIds,
+    skippedQuestionIds,
+    questionDrafts,
+  };
+}
+
+function loadAssessmentCatalogFromDisk() {
+  const normalizedDir = fileURLToPath(
+    new URL("../../../content/normalized", import.meta.url),
+  );
+  const files = readdirSync(normalizedDir).filter((file) =>
+    file.endsWith(".json"),
+  );
+  const catalog = new Map<string, AssessmentRecord>();
+
+  for (const file of files) {
+    const raw = readFileSync(join(normalizedDir, file), "utf8");
+    const assessment = JSON.parse(raw) as AssessmentRecord;
+    catalog.set(assessment.id, assessment);
+  }
+
+  return catalog;
+}
+
+class InMemoryWiseSandboxStore {
+  #bindings = new Map<string, WiseEntityBinding>();
+  #bindingsByExternalRef = new Map<string, WiseEntityBinding>();
+  #invitesByToken = new Map<string, WiseSandboxInviteRecord>();
+  #logs: WiseWriteLogEntry[] = [];
+  #syncedSubmissions = new Map<string, SessionGradingResponse[]>();
+
+  getBindings() {
+    return this.#bindings.values();
+  }
+
+  getBindingById(wiseId: string) {
+    return this.#bindings.get(wiseId);
+  }
+
+  getBindingByExternalRef(
+    entityType: WiseSandboxEntityType,
+    externalRef: string,
+  ) {
+    return this.#bindingsByExternalRef.get(`${entityType}:${externalRef}`);
+  }
+
+  saveBinding(binding: WiseEntityBinding) {
+    this.#bindings.set(binding.wiseId, binding);
+    this.#bindingsByExternalRef.set(
+      `${binding.entityType}:${binding.externalRef}`,
+      binding,
+    );
+  }
+
+  saveInvite(invite: WiseSandboxInviteRecord) {
+    this.#invitesByToken.set(invite.token, invite);
+  }
+
+  getInviteByToken(token: string) {
+    return this.#invitesByToken.get(token);
+  }
+
+  listLogs() {
+    return [...this.#logs];
+  }
+
+  appendLog(entry: WiseWriteLogEntry) {
+    this.#logs.unshift(entry);
+    this.#logs.splice(50);
+  }
+
+  saveSyncedSubmissions(testId: string, responses: SessionGradingResponse[]) {
+    this.#syncedSubmissions.set(testId, responses);
+  }
+
+  getSyncedSubmissions(testId: string) {
+    return this.#syncedSubmissions.get(testId) ?? [];
+  }
+}
+
+function createWiseWriteLog(
+  action: WiseAction,
+  endpoint: string,
+  dryRun: boolean,
+  payload: unknown,
+  targetWiseId?: string,
+): WiseWriteLogEntry {
+  const payloadPreview =
+    typeof payload === "string" ? payload : JSON.stringify(payload, null, 2);
+
+  return {
+    logId: randomUUID(),
+    occurredAt: toIsoNow(),
+    action,
+    endpoint,
+    dryRun,
+    targetWiseId,
+    payloadPreview: payloadPreview.slice(0, 1_000),
+  };
+}
+
+function createWiseClient(config: WiseClientConfig): WiseClient {
+  const host = config.host ?? "https://api.wiseapp.live";
+  const examHost = config.examHost ?? host;
+  const namespace = config.namespace ?? "sandbox";
+  const userAgent = config.userAgent ?? `VendorIntegrations/${namespace}`;
+  const liveConfigPresent = Boolean(
+    config.userId && config.apiKey && config.instituteId && config.namespace,
+  );
+  const liveWritesEnabled = liveConfigPresent && config.allowMutations === true;
+
+  async function request(
+    baseUrl: string,
+    path: string,
+    init?: RequestInit,
+  ): Promise<Record<string, unknown>> {
+    if (
+      !liveConfigPresent ||
+      !config.userId ||
+      !config.apiKey ||
+      !config.instituteId
+    ) {
+      throw new Error("Wise sandbox is not configured for live API calls.");
+    }
+
+    const url = path.startsWith("http") ? path : `${baseUrl}${path}`;
+    assertWiseSandboxEndpointAllowed(path);
+    const headers = new Headers(init?.headers ?? {});
+
+    headers.set(
+      "authorization",
+      `Basic ${Buffer.from(`${config.userId}:${config.apiKey}`).toString("base64")}`,
+    );
+    headers.set("x-api-key", config.apiKey);
+    headers.set("x-wise-namespace", namespace);
+    headers.set("user-agent", userAgent);
+    headers.set("content-type", "application/json");
+
+    const response = await fetch(url, {
+      ...init,
+      headers,
+    });
+    const text = await response.text();
+    const json = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+
+    if (!response.ok) {
+      const message =
+        typeof json.message === "string" ? json.message : response.statusText;
+      throw new Error(`Wise request failed (${response.status}): ${message}`);
+    }
+
+    return json;
+  }
+
+  return {
+    configured: liveConfigPresent,
+    mode: liveWritesEnabled ? "live" : "dry-run",
+    namespace,
+    launchUrlTemplate: config.launchUrlTemplate,
+    async getAccountUser() {
+      if (!liveConfigPresent) {
+        return {
+          wiseUserId: "dryrun-account-user",
+          name: "BeGifted Sandbox Owner",
+          namespace,
+          email: "sandbox-owner@example.invalid",
+        };
+      }
+
+      const response = await request(host, "/user/getUser", { method: "GET" });
+      const data = parseJsonResponse(response.data);
+
+      return {
+        wiseUserId:
+          typeof data.uuid === "string"
+            ? data.uuid
+            : typeof data._id === "string"
+              ? data._id
+              : "wise-account-user",
+        name: typeof data.name === "string" ? data.name : "Wise Account User",
+        namespace:
+          typeof data.namespace === "string" ? data.namespace : namespace,
+        email: typeof data.email === "string" ? data.email : undefined,
+      };
+    },
+    async createStudent(input) {
+      if (!liveWritesEnabled) {
+        return {
+          wiseId: `dry-student-${input.vendorUserId}`,
+          vendorUserId: input.vendorUserId,
+          displayName: input.displayName,
+          email: input.email,
+        };
+      }
+
+      const response = await request(
+        host,
+        `/vendors/institutes/${config.instituteId}/users`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            vendorUserId: input.vendorUserId,
+            name: input.displayName,
+            email: input.email,
+            phoneNumber: input.phoneNumber,
+            profile: "student",
+          }),
+        },
+      );
+      const user = parseJsonResponse(parseJsonResponse(response.data).user);
+
+      return {
+        wiseId:
+          extractWiseId(user._id) ??
+          extractWiseId(user.uuid) ??
+          input.vendorUserId,
+        vendorUserId: input.vendorUserId,
+        displayName:
+          typeof user.name === "string" ? user.name : input.displayName,
+        email: typeof user.email === "string" ? user.email : input.email,
+      };
+    },
+    async createCourse(input) {
+      if (!liveWritesEnabled) {
+        return {
+          wiseId: `dry-course-${slugify(input.displayName)}`,
+          displayName: input.displayName,
+          subject: input.subject,
+        };
+      }
+
+      const response = await request(host, "/teacher/addClass", {
+        method: "POST",
+        body: JSON.stringify({
+          name: input.displayName,
+          subject: input.subject,
+          instituteId: config.instituteId,
+          enableJoinMagicLink: true,
+          magicLinkLoginRequired: false,
+        }),
+      });
+      const data = parseJsonResponse(response.data);
+
+      return {
+        wiseId:
+          extractWiseId(data._id) ?? `course-${slugify(input.displayName)}`,
+        displayName:
+          typeof data.name === "string" ? data.name : input.displayName,
+        subject:
+          typeof data.subject === "string" ? data.subject : input.subject,
+      };
+    },
+    async assignCourseToStudent({ courseId, studentId }) {
+      if (!liveWritesEnabled) {
+        return;
+      }
+
+      await request(
+        host,
+        `/institutes/${config.instituteId}/assignClassToStudent`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            classId: courseId,
+            userId: studentId,
+            assign: true,
+          }),
+        },
+      );
+    },
+    async getCourseSections(courseId) {
+      if (!liveConfigPresent) {
+        return [{ sectionId: `dry-section-${courseId}`, name: "Section 1" }];
+      }
+
+      const response = await request(
+        host,
+        `/user/classes/${courseId}/contentTimeline?showSequentialLearningDisabledSections=true`,
+        { method: "GET" },
+      );
+      const data = parseJsonResponse(response.data);
+      const timeline = Array.isArray(data.timeline) ? data.timeline : [];
+
+      return timeline
+        .map((entry) => parseJsonResponse(entry))
+        .map((entry) => ({
+          sectionId: extractWiseId(entry._id) ?? "",
+          name: typeof entry.name === "string" ? entry.name : "Section 1",
+        }))
+        .filter((entry) => entry.sectionId.length > 0);
+    },
+    async createTest({ classId, displayName, sectionId }) {
+      if (!liveWritesEnabled) {
+        return {
+          wiseId: `dry-test-${slugify(displayName)}`,
+          classId,
+          displayName,
+        };
+      }
+
+      const response = await request(
+        host,
+        `/teacher/classes/${classId}/proxy/addTest`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            type: "UserInputOmrTest",
+            name: displayName,
+            sectionId,
+          }),
+        },
+      );
+      const data = parseJsonResponse(parseJsonResponse(response.data).data);
+
+      return {
+        wiseId: extractWiseId(data._id) ?? `test-${slugify(displayName)}`,
+        classId,
+        displayName: typeof data.name === "string" ? data.name : displayName,
+      };
+    },
+    async addQuestions({ classId, testId, questions }) {
+      if (!liveWritesEnabled) {
+        return;
+      }
+
+      await request(examHost, `/api/v1/teacher/tests/${testId}/questions`, {
+        method: "POST",
+        body: JSON.stringify({
+          class_id: classId,
+          current_role: "teacher",
+          questions: questions.map((question) => ({
+            text: question.text,
+            options: question.options ?? {},
+            answer: question.answer,
+            question_type: question.question_type,
+          })),
+        }),
+      });
+    },
+    async updateTestSettings({ classId, testId, displayName, questionDrafts }) {
+      if (!liveWritesEnabled) {
+        return;
+      }
+
+      const markingSchemes = Object.fromEntries(
+        Array.from(
+          new Set(questionDrafts.map((draft) => draft.question_type)),
+        ).map((questionType) => [
+          questionType,
+          {
+            correct_marks: 1,
+            incorrect_marks: 0,
+          },
+        ]),
+      );
+
+      await request(examHost, `/api/v2/teacher/tests/${testId}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          class_id: classId,
+          user_id: config.userId,
+          current_role: "teacher",
+          test_type: "UserInputOmrTest",
+          test: {
+            name: displayName,
+            description: "BeGifted Wise sandbox shadow test",
+            max_marks: questionDrafts.length,
+            duration: questionDrafts.length,
+            mock_test: true,
+            question_count: questionDrafts.length,
+            marking_schemes: markingSchemes,
+          },
+        }),
+      });
+    },
+    async publishTest({ classId, testId }) {
+      if (!liveWritesEnabled) {
+        return;
+      }
+
+      await request(examHost, `/api/v1/teacher/tests/${testId}/activate`, {
+        method: "PUT",
+        body: JSON.stringify({
+          class_id: classId,
+          user_id: config.userId,
+          current_role: "teacher",
+          test_id: testId,
+        }),
+      });
+    },
+    async getTestSubmissions({ classId, testId }) {
+      if (!liveConfigPresent) {
+        return {
+          submissions: [],
+        };
+      }
+
+      const response = await request(
+        examHost,
+        `/api/v1/teacher/tests/${testId}/submissions?class_id=${classId}&user_id=${config.userId}&current_role=teacher`,
+        { method: "GET" },
+      );
+      const data = parseJsonResponse(response.data);
+      const submissions = Array.isArray(data.submissions)
+        ? data.submissions
+        : [];
+
+      return {
+        submissions: submissions.map((submission) => {
+          const record = parseJsonResponse(submission);
+
+          return {
+            submissionId:
+              extractWiseId(record._id) ?? `submission-${randomUUID()}`,
+            userName:
+              typeof record.user_name === "string"
+                ? record.user_name
+                : "Wise Sandbox Student",
+            answers:
+              typeof record.answers === "object" && record.answers !== null
+                ? (record.answers as Record<string, string>)
+                : {},
+          };
+        }),
+      };
+    },
+  };
+}
+
+interface WiseSandboxServiceOptions {
+  client?: WiseClient;
+  store?: InMemoryWiseSandboxStore;
+  catalog?: Map<string, AssessmentRecord>;
+  now?: () => string;
+}
+
+export interface WiseSandboxService {
+  getAccountSnapshot(): Promise<{
+    deliveryProvider: "wise-sandbox";
+    mode: "dry-run" | "live";
+    configured: boolean;
+    account: WiseAccountUser;
+  }>;
+  createInvite(payload: CreateInviteRequest): Promise<CreateInviteResponse>;
+  getPublicInvite(
+    token: string,
+  ): { expired: boolean; invite: PublicInviteLookupResponse } | null;
+  resolveLaunchUrl(token: string): string | null;
+  syncOwnedTestSubmissions(testId: string): Promise<WiseSubmissionSyncResponse>;
+  listLogs(): WiseWriteLogEntry[];
+}
+
+const wiseAllowedEndpointPatterns = [
+  /^\/user\/getUser$/,
+  /^\/vendors\/institutes\/[^/]+\/users$/,
+  /^\/teacher\/addClass$/,
+  /^\/institutes\/[^/]+\/assignClassToStudent$/,
+  /^\/user\/classes\/[^/]+\/contentTimeline(?:\?.*)?$/,
+  /^\/teacher\/classes\/[^/]+\/proxy\/addTest$/,
+  /^\/api\/v1\/teacher\/tests\/[^/]+\/questions$/,
+  /^\/api\/v2\/teacher\/tests\/[^/]+$/,
+  /^\/api\/v1\/teacher\/tests\/[^/]+\/activate$/,
+  /^\/api\/v1\/teacher\/tests\/[^/]+\/submissions(?:\?.*)?$/,
+];
+
+const wiseBlockedEndpointPattern =
+  /(bill|billing|credit|fee|fees|consultation|chat|admin|invoice|payment)/i;
+
+export function assertWiseSandboxEndpointAllowed(path: string) {
+  if (wiseBlockedEndpointPattern.test(path)) {
+    throw new Error(`Wise sandbox blocked an unsafe endpoint path: ${path}.`);
+  }
+
+  const allowed = wiseAllowedEndpointPatterns.some((pattern) =>
+    pattern.test(path),
+  );
+
+  if (!allowed) {
+    throw new Error(
+      `Wise sandbox blocked a non-allowlisted endpoint path: ${path}.`,
+    );
+  }
+}
+
+function ensureSingleAssessment(assessmentVersionIds: string[]) {
+  if (assessmentVersionIds.length !== 1) {
+    throw new Error(
+      "Wise sandbox invite flow currently supports exactly one assessment per invite.",
+    );
+  }
+}
+
+function buildLaunchTarget(
+  client: WiseClient,
+  invite: Pick<
+    WiseSandboxInviteRecord,
+    "token" | "wiseCourseId" | "wiseTestId" | "wiseStudentId"
+  >,
+) {
+  const template = client.launchUrlTemplate;
+
+  if (template) {
+    return template
+      .replaceAll("{namespace}", client.namespace)
+      .replaceAll("{classId}", invite.wiseCourseId)
+      .replaceAll("{testId}", invite.wiseTestId)
+      .replaceAll("{studentId}", invite.wiseStudentId)
+      .replaceAll("{token}", invite.token);
+  }
+
+  const url = new URL(`https://${client.namespace}.wise.live`);
+  url.searchParams.set("mode", "wise-sandbox");
+  url.searchParams.set("classId", invite.wiseCourseId);
+  url.searchParams.set("testId", invite.wiseTestId);
+  url.searchParams.set("studentId", invite.wiseStudentId);
+  url.searchParams.set("inviteToken", invite.token);
+
+  return url.toString();
+}
+
+function createBinding(
+  entityType: WiseSandboxEntityType,
+  wiseId: string,
+  externalRef: string,
+  displayName: string,
+  metadata: WiseEntityBinding["metadata"],
+  now: string,
+): WiseEntityBinding {
+  return {
+    wiseId,
+    entityType,
+    owner: wiseSandboxOwner,
+    externalRef,
+    displayName,
+    createdAt: now,
+    metadata,
+  };
+}
+
+function getPublishedAssessmentBinding(
+  store: InMemoryWiseSandboxStore,
+  assessmentId: string,
+) {
+  return store.getBindingByExternalRef("test", assessmentId);
+}
+
+export function createWiseSandboxService(
+  options: WiseSandboxServiceOptions = {},
+): WiseSandboxService {
+  const store = options.store ?? new InMemoryWiseSandboxStore();
+  const client =
+    options.client ??
+    createWiseClient({
+      host: process.env.WISE_API_HOST,
+      examHost: process.env.WISE_EXAM_HOST,
+      userId: process.env.WISE_USER_ID,
+      apiKey: process.env.WISE_API_KEY,
+      instituteId: process.env.WISE_INSTITUTE_ID,
+      namespace: process.env.WISE_NAMESPACE,
+      userAgent: process.env.WISE_USER_AGENT,
+      allowMutations: process.env.WISE_SANDBOX_ALLOW_MUTATIONS === "true",
+      launchUrlTemplate: process.env.WISE_SANDBOX_LAUNCH_URL_TEMPLATE,
+    });
+  const catalog = options.catalog ?? loadAssessmentCatalogFromDisk();
+  const now = options.now ?? toIsoNow;
+
+  function assertOwnedMutation(
+    action: WiseWriteAction,
+    entityType: WiseSandboxEntityType,
+    binding: WiseEntityBinding | undefined,
+  ) {
+    const result = evaluateWiseWriteGuard({
+      action,
+      entityType,
+      targetWiseId: binding?.wiseId,
+      targetDisplayName: binding?.displayName,
+      bindings: store.getBindings(),
+    });
+
+    if (!result.allowed) {
+      throw new Error(result.reason);
+    }
+  }
+
+  async function logWiseWrite(
+    action: WiseWriteAction | WiseReadAction,
+    endpoint: string,
+    payload: unknown,
+    targetWiseId?: string,
+  ) {
+    const isWrite = wiseAllowedWriteActions.includes(action as WiseWriteAction);
+    if (!isWrite) {
+      return;
+    }
+
+    store.appendLog(
+      createWiseWriteLog(
+        action,
+        endpoint,
+        client.mode === "dry-run",
+        payload,
+        targetWiseId,
+      ),
+    );
+  }
+
+  async function getOrCreateDummyStudent(studentName: string) {
+    const syntheticIdentity = createSyntheticStudentIdentity(studentName);
+    const existing = store.getBindingByExternalRef(
+      "student",
+      syntheticIdentity.externalRef,
+    );
+    if (existing) {
+      return {
+        wiseId: existing.wiseId,
+        vendorUserId: syntheticIdentity.vendorUserId,
+        displayName: existing.displayName,
+        email: syntheticIdentity.email,
+      };
+    }
+
+    const displayName = createWiseSandboxStudentName(studentName);
+    await logWiseWrite(
+      "create-student",
+      "/vendors/institutes/:instituteId/users",
+      {
+        vendorUserId: syntheticIdentity.vendorUserId,
+        displayName,
+        email: syntheticIdentity.email,
+      },
+    );
+
+    const student = await client.createStudent({
+      vendorUserId: syntheticIdentity.vendorUserId,
+      displayName,
+      email: syntheticIdentity.email,
+      phoneNumber: syntheticIdentity.phoneNumber,
+    });
+
+    store.saveBinding(
+      createBinding(
+        "student",
+        student.wiseId,
+        syntheticIdentity.externalRef,
+        student.displayName,
+        {
+          vendorUserId: student.vendorUserId,
+          email: student.email,
+        },
+        now(),
+      ),
+    );
+
+    return student;
+  }
+
+  async function getOrCreateDummyCourse(assessment: AssessmentRecord) {
+    const existing = store.getBindingByExternalRef("course", assessment.id);
+    if (existing) {
+      return {
+        wiseId: existing.wiseId,
+        displayName: existing.displayName,
+        subject: assessment.subject,
+      };
+    }
+
+    const displayName = createWiseSandboxCourseName(assessment.title);
+    await logWiseWrite("create-course", "/teacher/addClass", {
+      displayName,
+      subject: assessment.subject,
+    });
+
+    const course = await client.createCourse({
+      displayName,
+      subject: assessment.subject,
+    });
+
+    store.saveBinding(
+      createBinding(
+        "course",
+        course.wiseId,
+        assessment.id,
+        course.displayName,
+        {
+          assessmentId: assessment.id,
+        },
+        now(),
+      ),
+    );
+
+    return course;
+  }
+
+  async function getOrCreateDummyTest(
+    assessment: AssessmentRecord,
+    course: WiseSandboxCourse,
+  ) {
+    const existing = getPublishedAssessmentBinding(store, assessment.id);
+    if (existing) {
+      return {
+        wiseId: existing.wiseId,
+        classId: course.wiseId,
+        displayName: existing.displayName,
+        publishedQuestionIds:
+          (existing.metadata?.publishedQuestionIds as string[] | undefined) ??
+          [],
+        skippedQuestionIds:
+          (existing.metadata?.skippedQuestionIds as string[] | undefined) ?? [],
+      };
+    }
+
+    const publishedAssessment = buildWisePublishedAssessment(assessment);
+    const sections = await client.getCourseSections(course.wiseId);
+    const section = sections[0];
+
+    if (!section) {
+      throw new Error("Wise sandbox course does not expose a content section.");
+    }
+
+    const displayName = createWiseSandboxTestName(assessment.title);
+    await logWiseWrite(
+      "create-test",
+      "/teacher/classes/:classId/proxy/addTest",
+      {
+        classId: course.wiseId,
+        displayName,
+        sectionId: section.sectionId,
+      },
+    );
+
+    const test = await client.createTest({
+      classId: course.wiseId,
+      displayName,
+      sectionId: section.sectionId,
+    });
+    const provisionalBinding = createBinding(
+      "test",
+      test.wiseId,
+      assessment.id,
+      test.displayName,
+      {
+        assessmentId: assessment.id,
+        classId: course.wiseId,
+        publishedQuestionIds: [],
+        skippedQuestionIds: publishedAssessment.skippedQuestionIds,
+      },
+      now(),
+    );
+    store.saveBinding(provisionalBinding);
+    assertOwnedMutation("add-test-questions", "test", provisionalBinding);
+
+    await logWiseWrite(
+      "add-test-questions",
+      "/api/v1/teacher/tests/:testId/questions",
+      {
+        classId: course.wiseId,
+        questions: publishedAssessment.questionDrafts,
+      },
+      test.wiseId,
+    );
+    await client.addQuestions({
+      classId: course.wiseId,
+      testId: test.wiseId,
+      questions: publishedAssessment.questionDrafts,
+    });
+    assertOwnedMutation("update-test-settings", "test", provisionalBinding);
+
+    await logWiseWrite(
+      "update-test-settings",
+      "/api/v2/teacher/tests/:testId",
+      {
+        classId: course.wiseId,
+        questionCount: publishedAssessment.questionDrafts.length,
+      },
+      test.wiseId,
+    );
+    await client.updateTestSettings({
+      classId: course.wiseId,
+      testId: test.wiseId,
+      displayName: test.displayName,
+      questionDrafts: publishedAssessment.questionDrafts,
+    });
+    assertOwnedMutation("publish-test", "test", provisionalBinding);
+
+    await logWiseWrite(
+      "publish-test",
+      "/api/v1/teacher/tests/:testId/activate",
+      { classId: course.wiseId },
+      test.wiseId,
+    );
+    await client.publishTest({ classId: course.wiseId, testId: test.wiseId });
+
+    const finalTest: WiseSandboxTest = {
+      wiseId: test.wiseId,
+      classId: course.wiseId,
+      displayName: test.displayName,
+      publishedQuestionIds: publishedAssessment.publishedQuestionIds,
+      skippedQuestionIds: publishedAssessment.skippedQuestionIds,
+    };
+
+    store.saveBinding({
+      ...provisionalBinding,
+      metadata: {
+        assessmentId: assessment.id,
+        classId: course.wiseId,
+        publishedQuestionIds: finalTest.publishedQuestionIds,
+        skippedQuestionIds: finalTest.skippedQuestionIds,
+      },
+    });
+
+    return finalTest;
+  }
+
+  async function assignDummyStudentToCourse(
+    course: WiseSandboxCourse,
+    student: WiseSandboxStudent,
+  ) {
+    const courseBinding = store.getBindingById(course.wiseId);
+    const studentBinding = store.getBindingById(student.wiseId);
+    assertOwnedMutation("assign-course-to-student", "course", courseBinding);
+    assertOwnedMutation("assign-course-to-student", "student", studentBinding);
+
+    await logWiseWrite(
+      "assign-course-to-student",
+      "/institutes/:instituteId/assignClassToStudent",
+      {
+        classId: course.wiseId,
+        studentId: student.wiseId,
+      },
+      course.wiseId,
+    );
+
+    await client.assignCourseToStudent({
+      courseId: course.wiseId,
+      studentId: student.wiseId,
+    });
+  }
+
+  return {
+    async getAccountSnapshot() {
+      return {
+        deliveryProvider: "wise-sandbox",
+        mode: client.mode,
+        configured: client.configured,
+        account: await client.getAccountUser(),
+      };
+    },
+    async createInvite(payload) {
+      ensureSingleAssessment(payload.assessmentVersionIds);
+      const [assessmentId] = payload.assessmentVersionIds;
+
+      if (!assessmentId) {
+        throw new Error(
+          "Wise sandbox invite flow currently supports exactly one assessment per invite.",
+        );
+      }
+
+      const assessment = catalog.get(assessmentId);
+
+      if (!assessment) {
+        throw new Error(
+          `Assessment ${assessmentId} was not found in the content catalog.`,
+        );
+      }
+
+      const student = await getOrCreateDummyStudent(payload.studentName);
+      const course = await getOrCreateDummyCourse(assessment);
+      const test = await getOrCreateDummyTest(assessment, course);
+
+      await assignDummyStudentToCourse(course, student);
+
+      const inviteId = randomUUID();
+      const token = createCoreInviteToken();
+      const provisionalInvite: WiseSandboxInviteRecord = {
+        inviteId,
+        token,
+        studentName: payload.studentName,
+        parentEmail: payload.parentEmail,
+        recipientEmails: payload.recipientEmails ?? [],
+        expiresAt: payload.expiresAt,
+        assessmentVersionIds: [assessment.id],
+        assessmentTitles: [assessment.title],
+        deliveryProvider: "wise-sandbox",
+        launchUrl: null,
+        dryRun: client.mode === "dry-run",
+        wiseStudentId: student.wiseId,
+        wiseCourseId: course.wiseId,
+        wiseTestId: test.wiseId,
+        publishedQuestionIds: test.publishedQuestionIds,
+        skippedQuestionIds: test.skippedQuestionIds,
+      };
+      provisionalInvite.launchUrl = `/api/public/invites/${token}/launch`;
+
+      store.saveInvite(provisionalInvite);
+
+      return {
+        inviteId,
+        token,
+        status: "sandbox_ready",
+        expiresAt: payload.expiresAt,
+        deliveryProvider: "wise-sandbox",
+        assessmentVersionIds: [assessment.id],
+        launchUrl: provisionalInvite.launchUrl,
+        dryRun: provisionalInvite.dryRun,
+        publishedQuestionIds: test.publishedQuestionIds,
+        skippedQuestionIds: test.skippedQuestionIds,
+      };
+    },
+    getPublicInvite(token) {
+      const invite = store.getInviteByToken(token);
+      if (!invite) {
+        return null;
+      }
+
+      const expired =
+        new Date(invite.expiresAt).getTime() < new Date(now()).getTime();
+
+      return {
+        expired,
+        invite: {
+          inviteId: invite.inviteId,
+          token: invite.token,
+          studentName: invite.studentName,
+          assessmentTitles: invite.assessmentTitles,
+          expiresAt: invite.expiresAt,
+          deliveryProvider: invite.deliveryProvider,
+          launchUrl: invite.launchUrl,
+          launchReady: !expired && invite.launchUrl !== null,
+          launchInstructions: invite.dryRun
+            ? "Wise sandbox is running in dry-run mode. The launch URL points to the sandbox bridge only."
+            : "This sandbox invite launches only BeGifted-owned Wise dummy entities.",
+        },
+      };
+    },
+    resolveLaunchUrl(token) {
+      const publicInvite = store.getInviteByToken(token);
+      if (!publicInvite) {
+        return null;
+      }
+
+      if (
+        new Date(publicInvite.expiresAt).getTime() < new Date(now()).getTime()
+      ) {
+        return null;
+      }
+
+      return buildLaunchTarget(client, publicInvite);
+    },
+    async syncOwnedTestSubmissions(testId) {
+      const testBinding = store.getBindingById(testId);
+      const guard = evaluateWiseWriteGuard({
+        action: "get-test-submissions",
+        entityType: "test",
+        targetWiseId: testId,
+        targetDisplayName: testBinding?.displayName,
+        bindings: store.getBindings(),
+      });
+
+      if (!testBinding || !guard.allowed) {
+        throw new Error(
+          "Submission sync blocked because the Wise test is not a BeGifted-owned sandbox entity.",
+        );
+      }
+
+      const classId = String(testBinding.metadata?.classId ?? "");
+      const assessmentId = String(testBinding.metadata?.assessmentId ?? "");
+      const assessment = catalog.get(assessmentId);
+
+      if (!classId || !assessment) {
+        throw new Error(
+          "Sandbox test binding is missing its assessment mapping.",
+        );
+      }
+
+      const publishedAssessment = buildWisePublishedAssessment(assessment);
+      const questionDraftsById = new Map(
+        publishedAssessment.questionDrafts.map((draft) => [
+          draft.questionId,
+          draft,
+        ]),
+      );
+      const bundle = await client.getTestSubmissions({ classId, testId });
+      const gradingResponses: SessionGradingResponse[] = [];
+      const syncedSubmissions: WiseSubmissionGradingRecord[] = [];
+
+      for (const submission of bundle.submissions) {
+        const answers = publishedAssessment.publishedQuestionIds.reduce<
+          SessionAnswerInput[]
+        >((accumulator, questionId, index) => {
+          const draft = questionDraftsById.get(questionId);
+          const fallbackAnswers = Object.values(submission.answers);
+          const answer =
+            submission.answers[questionId] ?? fallbackAnswers[index];
+
+          if (!draft || answer === undefined) {
+            return accumulator;
+          }
+
+          const acceptedAnswers =
+            draft.question_type === "FILL_IN_THE_BLANK"
+              ? draft.answer.split(",").map((value) => value.trim())
+              : [draft.answer];
+
+          accumulator.push({
+            submissionAnswerId: `${submission.submissionId}:${questionId}`,
+            questionId,
+            gradingMode: "deterministic",
+            answer,
+            acceptedAnswers,
+            maxScore: draft.marks,
+          });
+
+          return accumulator;
+        }, []);
+
+        const grading = evaluateSessionAnswers({
+          sessionId: `wise-sandbox:${submission.submissionId}`,
+          answers,
+        });
+
+        gradingResponses.push(grading);
+        syncedSubmissions.push({
+          submissionId: submission.submissionId,
+          userName: submission.userName,
+          sessionId: grading.sessionId,
+          gradingResultIds: grading.gradingResults.map((result) => result.id),
+        });
+      }
+
+      store.saveSyncedSubmissions(testId, gradingResponses);
+
+      return {
+        deliveryProvider: "wise-sandbox",
+        testId,
+        assessmentId,
+        totalSubmissions: syncedSubmissions.length,
+        syncedSubmissions,
+      };
+    },
+    listLogs() {
+      return store.listLogs();
+    },
+  };
+}

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildServer } from "../src/server.js";
+import { createWiseSandboxService } from "../src/wise-sandbox.js";
 
 describe("api health and grading", () => {
   it("returns a healthy response", async () => {
@@ -405,6 +406,223 @@ describe("api health and grading", () => {
     expect(response.json()).toMatchObject({
       error: "not_found",
       message: "Grading result was not found.",
+    });
+
+    await server.close();
+  });
+
+  it("creates and exposes Wise sandbox invites without touching live entities", async () => {
+    const server = buildServer();
+    const createResponse = await server.inject({
+      method: "POST",
+      url: "/api/invites",
+      payload: {
+        studentName: "Alex Chen",
+        parentEmail: "parent@example.com",
+        recipientEmails: ["advisor@example.com"],
+        assessmentVersionIds: ["science-uk-year-7-foundation-pretest"],
+        expiresAt: "2026-03-20T23:59:59.000Z",
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(200);
+    expect(createResponse.json()).toMatchObject({
+      status: "sandbox_ready",
+      deliveryProvider: "wise-sandbox",
+      dryRun: true,
+      assessmentVersionIds: ["science-uk-year-7-foundation-pretest"],
+    });
+
+    const { token } = createResponse.json() as { token: string };
+    const inviteResponse = await server.inject({
+      method: "GET",
+      url: `/api/public/invites/${token}`,
+    });
+
+    expect(inviteResponse.statusCode).toBe(200);
+    expect(inviteResponse.json()).toMatchObject({
+      token,
+      studentName: "Alex Chen",
+      deliveryProvider: "wise-sandbox",
+      launchReady: true,
+      assessmentTitles: ["Year 7 Science Foundation Pre-Test"],
+    });
+
+    const launchResponse = await server.inject({
+      method: "GET",
+      url: `/api/public/invites/${token}/launch`,
+    });
+
+    expect(launchResponse.statusCode).toBe(303);
+    expect(launchResponse.headers.location).toContain("mode=wise-sandbox");
+
+    const logResponse = await server.inject({
+      method: "GET",
+      url: "/api/wise/sandbox/logs",
+    });
+
+    expect(logResponse.statusCode).toBe(200);
+    expect(logResponse.json()).toMatchObject({
+      total: 7,
+    });
+
+    await server.close();
+  });
+
+  it("returns 410 for expired Wise sandbox invites", async () => {
+    const wiseSandbox = createWiseSandboxService({
+      now: () => "2026-03-18T00:00:00.000Z",
+    });
+    await wiseSandbox.createInvite({
+      studentName: "Expired Student",
+      parentEmail: "expired@example.com",
+      assessmentVersionIds: ["science-uk-year-7-foundation-pretest"],
+      expiresAt: "2026-03-17T23:59:59.000Z",
+    });
+
+    const invite = wiseSandbox.getPublicInvite(
+      (
+        await wiseSandbox.createInvite({
+          studentName: "Ready Student",
+          parentEmail: "ready@example.com",
+          assessmentVersionIds: ["science-uk-year-7-foundation-pretest"],
+          expiresAt: "2026-03-19T23:59:59.000Z",
+        })
+      ).token,
+    );
+
+    expect(invite?.expired).toBe(false);
+
+    const expiredServer = buildServer({
+      wiseSandbox: createWiseSandboxService({
+        now: () => "2026-03-18T00:00:00.000Z",
+      }),
+    });
+    const expiredCreateResponse = await expiredServer.inject({
+      method: "POST",
+      url: "/api/invites",
+      payload: {
+        studentName: "Expired Student",
+        parentEmail: "expired@example.com",
+        assessmentVersionIds: ["science-uk-year-7-foundation-pretest"],
+        expiresAt: "2026-03-17T23:59:59.000Z",
+      },
+    });
+    const expiredToken = (expiredCreateResponse.json() as { token: string })
+      .token;
+    const expiredResponse = await expiredServer.inject({
+      method: "GET",
+      url: `/api/public/invites/${expiredToken}`,
+    });
+
+    expect(expiredResponse.statusCode).toBe(410);
+    expect(expiredResponse.json()).toMatchObject({
+      error: "expired",
+    });
+
+    await expiredServer.close();
+  });
+
+  it("syncs submissions only for BeGifted-owned Wise sandbox tests", async () => {
+    let createdTestId = "";
+    const wiseSandbox = createWiseSandboxService({
+      client: {
+        configured: false,
+        mode: "dry-run",
+        namespace: "sandbox",
+        launchUrlTemplate: undefined,
+        async getAccountUser() {
+          return {
+            wiseUserId: "dry-account",
+            name: "Sandbox",
+            namespace: "sandbox",
+          };
+        },
+        async createStudent(input) {
+          return {
+            wiseId: `student-${input.vendorUserId}`,
+            vendorUserId: input.vendorUserId,
+            displayName: input.displayName,
+            email: input.email,
+          };
+        },
+        async createCourse(input) {
+          return {
+            wiseId: "course-123",
+            displayName: input.displayName,
+            subject: input.subject,
+          };
+        },
+        async assignCourseToStudent() {},
+        async getCourseSections() {
+          return [{ sectionId: "section-1", name: "Section 1" }];
+        },
+        async createTest(input) {
+          createdTestId = "test-123";
+
+          return {
+            wiseId: createdTestId,
+            classId: input.classId,
+            displayName: input.displayName,
+          };
+        },
+        async addQuestions() {},
+        async updateTestSettings() {},
+        async publishTest() {},
+        async getTestSubmissions() {
+          return {
+            submissions: [
+              {
+                submissionId: "submission-1",
+                userName: "BGT Dummy",
+                answers: {
+                  q1: "b",
+                  q2: "c",
+                  q3: "c",
+                  q5: "c",
+                  q6: "b",
+                  q7: "b",
+                  q9: "b",
+                  q11: "they changed the amount of sugar",
+                },
+              },
+            ],
+          };
+        },
+      },
+      now: () => "2026-03-18T00:00:00.000Z",
+    });
+
+    await wiseSandbox.createInvite({
+      studentName: "Sandbox Student",
+      parentEmail: "sandbox@example.com",
+      assessmentVersionIds: ["science-uk-year-7-foundation-pretest"],
+      expiresAt: "2026-03-19T23:59:59.000Z",
+    });
+
+    const syncResponse =
+      await wiseSandbox.syncOwnedTestSubmissions(createdTestId);
+    expect(syncResponse).toMatchObject({
+      deliveryProvider: "wise-sandbox",
+      testId: "test-123",
+      assessmentId: "science-uk-year-7-foundation-pretest",
+      totalSubmissions: 1,
+      syncedSubmissions: [
+        {
+          submissionId: "submission-1",
+        },
+      ],
+    });
+
+    const server = buildServer({ wiseSandbox });
+    const blockedResponse = await server.inject({
+      method: "POST",
+      url: "/api/wise/sandbox/tests/not-owned/submissions/sync",
+    });
+
+    expect(blockedResponse.statusCode).toBe(403);
+    expect(blockedResponse.json()).toMatchObject({
+      error: "sync_blocked",
     });
 
     await server.close();

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -1,0 +1,6 @@
+export const apiBaseUrl =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+
+export function buildApiUrl(path: string) {
+  return `${apiBaseUrl}${path}`;
+}

--- a/apps/web/app/s/[token]/page.tsx
+++ b/apps/web/app/s/[token]/page.tsx
@@ -1,8 +1,21 @@
 import { Button, Card, PageShell } from "@begifted/ui";
 import type { CSSProperties } from "react";
+import { buildApiUrl } from "../../lib/api";
 
 interface StudentLandingProps {
   params: Promise<{ token: string }>;
+}
+
+interface InviteLookupResult {
+  inviteId: string;
+  token: string;
+  studentName: string;
+  assessmentTitles: string[];
+  expiresAt: string;
+  deliveryProvider: "wise-sandbox";
+  launchUrl: string | null;
+  launchReady: boolean;
+  launchInstructions: string;
 }
 
 const tealGradient =
@@ -80,31 +93,77 @@ const stepDesc: CSSProperties = {
 const steps = [
   {
     number: "1",
-    title: "Verify your details",
+    title: "Verify your sandbox invite",
     description:
-      "Confirm your name and the assessments assigned to you before starting.",
+      "Confirm your assigned assessment before launching the BeGifted sandbox bridge.",
   },
   {
     number: "2",
-    title: "Complete the pre-test",
+    title: "Open the Wise sandbox test",
     description:
-      "Answer each section at your own pace. Your progress is saved automatically.",
+      "The launch link opens only BeGifted-owned dummy Wise entities, never live classes or students.",
   },
   {
     number: "3",
-    title: "Submit your responses",
+    title: "Return for grading and diagnostics",
     description:
-      "Review your answers and submit. You won't be able to change responses after submission.",
+      "Sandbox submissions are pulled back into BeGifted for shadow grading and diagnostics.",
   },
 ];
+
+export const dynamic = "force-dynamic";
+
+async function loadInvite(token: string) {
+  const response = await fetch(buildApiUrl(`/api/public/invites/${token}`), {
+    cache: "no-store",
+  });
+
+  if (response.status === 404) {
+    return { status: "missing" as const };
+  }
+
+  if (response.status === 410) {
+    return { status: "expired" as const };
+  }
+
+  if (!response.ok) {
+    return { status: "error" as const };
+  }
+
+  return {
+    status: "ready" as const,
+    invite: (await response.json()) as InviteLookupResult,
+  };
+}
 
 export default async function StudentLandingPage({
   params,
 }: StudentLandingProps) {
   const { token } = await params;
+  const inviteState = await loadInvite(token);
 
-  // Token validation will call GET /api/public/invites/:token once backend is ready.
-  // For now we render the shell unconditionally.
+  if (inviteState.status !== "ready") {
+    const message =
+      inviteState.status === "expired"
+        ? "This sandbox invite has expired. Ask BeGifted to issue a new test link."
+        : inviteState.status === "missing"
+          ? "This sandbox invite could not be found."
+          : "BeGifted could not load your sandbox invite right now.";
+
+    return (
+      <PageShell maxWidth={600} gradient={tealGradient}>
+        <Card accent="#0f766e">
+          <div style={accentBar} />
+          <p style={tagline}>BeGifted Assessment</p>
+          <h1 style={heading}>Sandbox invite unavailable</h1>
+          <p style={body}>{message}</p>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  const { invite } = inviteState;
+  const launchBridgeUrl = buildApiUrl(`/api/public/invites/${token}/launch`);
 
   return (
     <PageShell maxWidth={600} gradient={tealGradient}>
@@ -113,9 +172,9 @@ export default async function StudentLandingPage({
         <p style={tagline}>BeGifted Assessment</p>
         <h1 style={heading}>Welcome to your pre-test</h1>
         <p style={body}>
-          You&rsquo;ve been invited to complete an academic assessment. This
-          helps your instructor understand your current level and recommend the
-          best learning path for you.
+          You&rsquo;ve been invited to complete a BeGifted-managed sandbox
+          assessment. This launch path uses only dummy Wise entities and does
+          not touch any live student, class, billing, or credit records.
         </p>
       </Card>
 
@@ -146,23 +205,46 @@ export default async function StudentLandingPage({
       <Card accent="#0f766e" style={{ textAlign: "center" as const }}>
         <p
           style={{
+            margin: "0 0 10px",
+            fontSize: 14,
+            color: "#0f766e",
+            fontWeight: 600,
+          }}
+        >
+          Assigned assessment: {invite.assessmentTitles.join(", ")}
+        </p>
+        <p
+          style={{
             margin: "0 0 16px",
             fontSize: 14,
             color: "#57534e",
             lineHeight: 1.5,
           }}
         >
-          When you&rsquo;re ready, click below to begin. Make sure you have a
-          quiet space and enough time to finish without interruption.
+          {invite.launchInstructions}
         </p>
-        <Button
-          style={{
-            background: "linear-gradient(135deg, #0f766e, #14b8a6)",
-            boxShadow: "0 4px 14px rgba(15, 118, 110, 0.3)",
-          }}
-        >
-          Begin assessment
-        </Button>
+        {invite.launchReady ? (
+          <a
+            href={launchBridgeUrl}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: "12px 28px",
+              borderRadius: 14,
+              fontSize: 15,
+              fontWeight: 600,
+              color: "#fff",
+              textDecoration: "none",
+              background: "linear-gradient(135deg, #0f766e, #14b8a6)",
+              boxShadow: "0 4px 14px rgba(15, 118, 110, 0.3)",
+            }}
+          >
+            Launch sandbox assessment
+          </a>
+        ) : (
+          <Button disabled>Launch unavailable</Button>
+        )}
         <p
           style={{
             margin: "12px 0 0",
@@ -170,7 +252,7 @@ export default async function StudentLandingPage({
             color: "#a8a29e",
           }}
         >
-          Invite token: {token.slice(0, 8)}&hellip;
+          Invite token: {invite.token.slice(0, 8)}&hellip;
         </p>
       </Card>
     </PageShell>

--- a/apps/web/app/staff/invites/new/page.tsx
+++ b/apps/web/app/staff/invites/new/page.tsx
@@ -3,6 +3,9 @@
 import { Button, Card, PageShell, TextInput } from "@begifted/ui";
 import type { CSSProperties, FormEvent } from "react";
 import { useState } from "react";
+import { buildApiUrl } from "../../../lib/api";
+
+const seededAssessmentId = "science-uk-year-7-foundation-pretest";
 
 const headerAccent: CSSProperties = {
   width: 42,
@@ -83,6 +86,15 @@ export default function NewInvitePage() {
   const [recipientInput, setRecipientInput] = useState("");
   const [recipientEmails, setRecipientEmails] = useState<string[]>([]);
   const [expiresAt, setExpiresAt] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [createdInvite, setCreatedInvite] = useState<null | {
+    token: string;
+    launchUrl: string | null;
+    dryRun: boolean;
+    publishedQuestionIds: string[];
+    skippedQuestionIds: string[];
+  }>(null);
 
   function addRecipient() {
     const email = recipientInput.trim();
@@ -96,9 +108,56 @@ export default function NewInvitePage() {
     setRecipientEmails((prev) => prev.filter((e) => e !== email));
   }
 
-  function handleSubmit(e: FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    // Submission will be wired to POST /api/invites once backend is ready.
+    setSubmitting(true);
+    setSubmitError(null);
+    setCreatedInvite(null);
+
+    try {
+      const response = await fetch(buildApiUrl("/api/invites"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          studentName,
+          parentEmail,
+          recipientEmails,
+          assessmentVersionIds: [seededAssessmentId],
+          expiresAt: new Date(`${expiresAt}T23:59:59.000Z`).toISOString(),
+        }),
+      });
+      const payload = (await response.json()) as
+        | {
+            token: string;
+            launchUrl: string | null;
+            dryRun: boolean;
+            publishedQuestionIds: string[];
+            skippedQuestionIds: string[];
+          }
+        | { message?: string };
+
+      if (!response.ok) {
+        throw new Error(
+          "message" in payload && typeof payload.message === "string"
+            ? payload.message
+            : "Failed to create Wise sandbox invite.",
+        );
+      }
+
+      if (!("token" in payload)) {
+        throw new Error("Wise sandbox invite response was incomplete.");
+      }
+
+      setCreatedInvite(payload);
+    } catch (error) {
+      setSubmitError(
+        error instanceof Error ? error.message : "Failed to create invite.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   return (
@@ -108,8 +167,9 @@ export default function NewInvitePage() {
         <p style={tagline}>Staff Portal</p>
         <h1 style={heading}>Create Assessment Invite</h1>
         <p style={subtitle}>
-          Send a secure pre-test link to a student. The invite will include the
-          selected assessments and expire on the date you choose.
+          Send a BeGifted-managed Wise sandbox link to a dummy-only pre-test.
+          This flow never attaches anything to live Wise students, classes, or
+          billing records.
         </p>
       </Card>
 
@@ -199,14 +259,71 @@ export default function NewInvitePage() {
               lineHeight: 1.5,
             }}
           >
-            Assessment selection will be available once the content catalogue is
-            populated. For now, invites will be created without specific
-            assessment bindings.
+            Sandbox mode currently publishes one seeded assessment:
+            <strong> Year 7 Science Foundation Pre-Test</strong>. Only
+            deterministic questions supported by Wise are published; all other
+            items stay in BeGifted for later grading and diagnostics.
           </p>
 
+          <div style={chipRow}>
+            <span style={chip}>Sandbox only</span>
+            <span style={chip}>Dummy Wise student</span>
+            <span style={chip}>No live class mutations</span>
+          </div>
+
+          {submitError ? (
+            <p style={{ marginTop: 16, color: "#b91c1c", fontSize: 14 }}>
+              {submitError}
+            </p>
+          ) : null}
+
+          {createdInvite ? (
+            <div
+              style={{
+                marginTop: 18,
+                padding: 16,
+                borderRadius: 16,
+                background: "rgba(245, 158, 11, 0.08)",
+                border: "1px solid rgba(180, 83, 9, 0.18)",
+              }}
+            >
+              <p style={{ margin: 0, fontWeight: 600, color: "#92400e" }}>
+                Sandbox invite created
+              </p>
+              <p style={{ margin: "8px 0 0", fontSize: 14, color: "#57534e" }}>
+                Token: {createdInvite.token}
+              </p>
+              <p style={{ margin: "6px 0 0", fontSize: 14, color: "#57534e" }}>
+                Published to Wise: {createdInvite.publishedQuestionIds.length}{" "}
+                questions
+              </p>
+              <p style={{ margin: "6px 0 0", fontSize: 14, color: "#57534e" }}>
+                Kept out of Wise: {createdInvite.skippedQuestionIds.length}{" "}
+                questions
+              </p>
+              <p style={{ margin: "6px 0 0", fontSize: 14, color: "#57534e" }}>
+                Mode: {createdInvite.dryRun ? "Dry run" : "Live sandbox"}
+              </p>
+              {createdInvite.launchUrl ? (
+                <p style={{ margin: "10px 0 0", fontSize: 14 }}>
+                  <a
+                    href={buildApiUrl(createdInvite.launchUrl)}
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{ color: "#0f766e", fontWeight: 600 }}
+                  >
+                    Open launch bridge
+                  </a>
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
           <div style={{ display: "flex", gap: 12, marginTop: 8 }}>
-            <Button type="submit">Create invite</Button>
-            <Button type="button" variant="secondary">
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Creating..." : "Create sandbox invite"}
+            </Button>
+            <Button type="button" variant="secondary" disabled>
               Save draft
             </Button>
           </div>

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -11,7 +11,7 @@
 
 ### `POST /api/invites`
 
-Creates an assessment invite.
+Creates a Wise shadow sandbox invite.
 
 Request fields:
 
@@ -24,8 +24,20 @@ Request fields:
 Response fields:
 
 - `inviteId`
+- `token`
 - `status`
 - `expiresAt`
+- `deliveryProvider`
+- `launchUrl`
+- `dryRun`
+- `publishedQuestionIds`
+- `skippedQuestionIds`
+
+Notes:
+
+- current sandbox flow supports exactly one assessment per invite
+- current sandbox flow provisions only BeGifted-owned dummy Wise entities
+- live Wise students, classes, billing, fees, and credits are out of scope and must not be touched
 
 ### `POST /api/invites/:inviteId/send`
 
@@ -33,7 +45,34 @@ Triggers email delivery of the invite link.
 
 ### `GET /api/public/invites/:token`
 
-Returns token validity, student-safe metadata, and assigned assessments.
+Returns token validity, student-safe metadata, assigned assessments, and sandbox launch metadata.
+
+Response fields:
+
+- `inviteId`
+- `token`
+- `studentName`
+- `assessmentTitles`
+- `expiresAt`
+- `deliveryProvider`
+- `launchUrl`
+- `launchReady`
+- `launchInstructions`
+
+Error behavior:
+
+- `404` when the invite token does not exist
+- `410` when the invite has expired
+
+### `GET /api/public/invites/:token/launch`
+
+Validates the invite and redirects to the Wise sandbox launch target.
+
+Error behavior:
+
+- `404` when the invite token does not exist
+- `410` when the invite has expired
+- `409` when the launch target is unavailable
 
 ### `POST /api/public/sessions/:sessionId/autosave`
 
@@ -104,6 +143,43 @@ Marks a report approved and emits `report.approved`.
 
 Dispatches the final report to recipients.
 
+### `GET /api/wise/sandbox/account`
+
+Returns the Wise sandbox connectivity snapshot.
+
+Response fields:
+
+- `deliveryProvider`
+- `mode`
+- `configured`
+- `account`
+
+### `GET /api/wise/sandbox/logs`
+
+Returns recent Wise sandbox write logs.
+
+Response fields:
+
+- `total`
+- `items`
+
+### `POST /api/wise/sandbox/tests/:testId/submissions/sync`
+
+Pulls submissions only for BeGifted-owned Wise sandbox tests and maps them into the grading shell.
+
+Response fields:
+
+- `deliveryProvider`
+- `testId`
+- `assessmentId`
+- `totalSubmissions`
+- `syncedSubmissions`
+
+Error behavior:
+
+- `403` when the test is not a BeGifted-owned sandbox binding
+- `400` when the binding is incomplete or the sync request cannot be satisfied safely
+
 ## Event contracts
 
 - `invite.created`
@@ -128,3 +204,4 @@ Each event payload must include:
 - public token endpoints return `404` or `410` for invalid or expired links
 - submission endpoints reject writes after final submit
 - report send endpoints reject when unresolved reviews remain
+- Wise shadow endpoints default to dry-run behavior unless `WISE_SANDBOX_ALLOW_MUTATIONS=true`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,11 +24,11 @@
 
 1. Staff creates an invite and selects assessment templates.
 2. API stores the invite, recipient data, and expiration policy.
-3. Email service sends a one-time access link.
-4. Student uses the web app to complete the assessment.
-5. Submission answers are persisted incrementally.
-6. Objective grading runs synchronously or in a background job.
-7. Subjective items are scored with rubric-assisted logic and review flags.
+3. In Wise shadow mode, API provisions only BeGifted-owned dummy Wise entities.
+4. Email or staff launch surfaces send a one-time access link.
+5. Student uses the web app to open the sandbox launch bridge.
+6. Wise hosts the dummy sandbox test for objective-supported items only.
+7. BeGifted pulls sandbox submissions back into the grading shell.
 8. Diagnostics and recommendation rules assemble the report payload.
 9. Staff validates the result.
 10. Approved report is rendered to PDF and distributed.
@@ -55,6 +55,7 @@
 - raw binary assets enter `content/raw`
 - normalized JSON is stored in `content/normalized`
 - runtime content is loaded into database records or object storage-backed references
+- Wise shadow publishing maps supported deterministic questions into BeGifted-owned dummy Wise tests
 - submissions generate grading results and diagnostics
 - approved results generate PDF artifacts and email events
 
@@ -63,6 +64,8 @@
 - staff authenticate through managed auth
 - students use secure invite tokens rather than full accounts in V1
 - invite tokens map to assessment sessions with limited lifetime and single-submission policy
+- Wise shadow mode never attaches live Wise data to existing students or classes
+- Wise shadow writes are dry-run by default unless sandbox mutations are explicitly enabled
 
 ## Grading pipeline
 
@@ -83,6 +86,6 @@
 - GitHub: engineering workflow, issues, Projects, PR gating
 - Supabase: database, storage, auth, row-level security
 - Vercel: frontend deployment and preview URLs
+- Wise: dummy-only shadow delivery for sandbox students and tests
 - Email provider: invite and report delivery
 - Sentry: runtime monitoring
-

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -47,3 +47,9 @@
 - Status: accepted
 - Decision: keep the grading seed and review-resolution payload shapes in `packages/core`, while the API shell uses in-memory storage until persistence and job orchestration land
 - Rationale: allows route consumers to integrate against one shared contract source without prematurely introducing database or workflow infrastructure
+
+## ADR-009: Wise shadow integration is dummy-only and additive
+
+- Status: accepted
+- Decision: integrate with Wise only through a sandbox shadow layer that creates and mutates BeGifted-owned dummy students, courses, and tests
+- Rationale: the live Wise tenant already carries production student, class, billing, and credit data, so the integration must default to dry-run behavior and block any mutation path outside the reserved BeGifted sandbox scope

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./contracts.js";
 export * from "./grading.js";
 export * from "./grading-shell.js";
+export * from "./wise-shadow.js";

--- a/packages/core/src/wise-shadow.ts
+++ b/packages/core/src/wise-shadow.ts
@@ -1,0 +1,276 @@
+import { createHash, randomUUID } from "node:crypto";
+
+export const wiseSandboxOwner = "begifted-sandbox" as const;
+
+export const wiseSandboxStudentPrefix = "BGT-DUMMY";
+export const wiseSandboxCoursePrefix = "BGT-SANDBOX";
+export const wiseSandboxTestPrefix = "BGT-TEST";
+
+export const wiseAllowedWriteActions = [
+  "create-student",
+  "create-course",
+  "assign-course-to-student",
+  "create-test",
+  "add-test-questions",
+  "update-test-settings",
+  "publish-test",
+] as const;
+
+export const wiseReadActions = [
+  "get-account-user",
+  "get-test-submissions",
+] as const;
+
+export type WiseSandboxEntityType = "student" | "course" | "test";
+
+export type WiseWriteAction = (typeof wiseAllowedWriteActions)[number];
+export type WiseReadAction = (typeof wiseReadActions)[number];
+export type WiseAction = WiseWriteAction | WiseReadAction;
+
+export interface WiseEntityBinding {
+  wiseId: string;
+  entityType: WiseSandboxEntityType;
+  owner: typeof wiseSandboxOwner;
+  externalRef: string;
+  displayName: string;
+  createdAt: string;
+  metadata?: Record<string, string | string[] | number | boolean | null>;
+}
+
+export interface WiseWriteGuardInput {
+  action: WiseAction;
+  entityType?: WiseSandboxEntityType;
+  targetWiseId?: string;
+  targetDisplayName?: string;
+  bindings?: Iterable<WiseEntityBinding>;
+}
+
+export interface WiseWriteGuardResult {
+  allowed: boolean;
+  action: WiseAction;
+  dryRunOnly: boolean;
+  reason: string;
+}
+
+export interface CreateInviteRequest {
+  studentName: string;
+  parentEmail: string;
+  recipientEmails?: string[];
+  assessmentVersionIds: string[];
+  expiresAt: string;
+}
+
+export interface CreateInviteResponse {
+  inviteId: string;
+  token: string;
+  status: "sandbox_ready";
+  expiresAt: string;
+  deliveryProvider: "wise-sandbox";
+  assessmentVersionIds: string[];
+  launchUrl: string | null;
+  dryRun: boolean;
+  publishedQuestionIds: string[];
+  skippedQuestionIds: string[];
+}
+
+export interface PublicInviteLookupResponse {
+  inviteId: string;
+  token: string;
+  studentName: string;
+  assessmentTitles: string[];
+  expiresAt: string;
+  deliveryProvider: "wise-sandbox";
+  launchUrl: string | null;
+  launchReady: boolean;
+  launchInstructions: string;
+}
+
+export interface WiseSandboxStudent {
+  wiseId: string;
+  vendorUserId: string;
+  displayName: string;
+  email: string;
+}
+
+export interface WiseSandboxCourse {
+  wiseId: string;
+  displayName: string;
+  subject: string;
+}
+
+export interface WiseSandboxTest {
+  wiseId: string;
+  classId: string;
+  displayName: string;
+  publishedQuestionIds: string[];
+  skippedQuestionIds: string[];
+}
+
+export interface WiseWriteLogEntry {
+  logId: string;
+  occurredAt: string;
+  action: WiseAction;
+  endpoint: string;
+  dryRun: boolean;
+  targetWiseId?: string;
+  payloadPreview: string;
+}
+
+export interface WiseSubmissionGradingRecord {
+  submissionId: string;
+  userName: string;
+  sessionId: string;
+  gradingResultIds: string[];
+}
+
+export interface WiseSubmissionSyncResponse {
+  deliveryProvider: "wise-sandbox";
+  testId: string;
+  assessmentId: string;
+  totalSubmissions: number;
+  syncedSubmissions: WiseSubmissionGradingRecord[];
+}
+
+const namePrefixesByEntityType: Record<WiseSandboxEntityType, string> = {
+  student: wiseSandboxStudentPrefix,
+  course: wiseSandboxCoursePrefix,
+  test: wiseSandboxTestPrefix,
+};
+
+export function getWiseSandboxPrefix(entityType: WiseSandboxEntityType) {
+  return namePrefixesByEntityType[entityType];
+}
+
+export function createWiseSandboxStudentName(studentName: string) {
+  const externalRef = createWiseSandboxExternalRef(studentName);
+  const suffix = externalRef.slice(-6).toUpperCase();
+
+  return `${wiseSandboxStudentPrefix} Student ${suffix}`;
+}
+
+export function createWiseSandboxCourseName(assessmentTitle: string) {
+  return `${wiseSandboxCoursePrefix} ${assessmentTitle.trim()}`;
+}
+
+export function createWiseSandboxTestName(assessmentTitle: string) {
+  return `${wiseSandboxTestPrefix} ${assessmentTitle.trim()}`;
+}
+
+export function createWiseSandboxToken() {
+  return randomUUID();
+}
+
+export function createWiseSandboxExternalRef(seed: string) {
+  const normalized = seed.trim().toLowerCase();
+  const digest = createHash("sha1")
+    .update(normalized)
+    .digest("hex")
+    .slice(0, 12);
+
+  return `bgt-sandbox-${digest}`;
+}
+
+export function isOwnedWiseBinding(
+  binding: WiseEntityBinding | undefined,
+  entityType: WiseSandboxEntityType,
+) {
+  return (
+    binding?.owner === wiseSandboxOwner &&
+    binding.entityType === entityType &&
+    binding.displayName.startsWith(getWiseSandboxPrefix(entityType))
+  );
+}
+
+export function evaluateWiseWriteGuard({
+  action,
+  entityType,
+  targetWiseId,
+  targetDisplayName,
+  bindings = [],
+}: WiseWriteGuardInput): WiseWriteGuardResult {
+  const isWriteAction = wiseAllowedWriteActions.includes(
+    action as WiseWriteAction,
+  );
+  if (!isWriteAction) {
+    return {
+      allowed: true,
+      action,
+      dryRunOnly: false,
+      reason: "Read-only Wise action allowed.",
+    };
+  }
+
+  if (!entityType) {
+    return {
+      allowed: true,
+      action,
+      dryRunOnly: false,
+      reason: "Creation action allowed without an existing Wise entity target.",
+    };
+  }
+
+  if (!targetWiseId || !targetDisplayName) {
+    return {
+      allowed: false,
+      action,
+      dryRunOnly: true,
+      reason:
+        "Mutation blocked because target Wise ownership could not be verified.",
+    };
+  }
+
+  const binding = Array.from(bindings).find(
+    (candidate) =>
+      candidate.wiseId === targetWiseId && candidate.entityType === entityType,
+  );
+
+  if (!binding || !isOwnedWiseBinding(binding, entityType)) {
+    return {
+      allowed: false,
+      action,
+      dryRunOnly: true,
+      reason:
+        "Mutation blocked because the Wise entity is not BeGifted-owned sandbox data.",
+    };
+  }
+
+  if (!targetDisplayName.startsWith(getWiseSandboxPrefix(entityType))) {
+    return {
+      allowed: false,
+      action,
+      dryRunOnly: true,
+      reason:
+        "Mutation blocked because the Wise entity does not use the reserved sandbox naming prefix.",
+    };
+  }
+
+  return {
+    allowed: true,
+    action,
+    dryRunOnly: false,
+    reason: "Mutation allowed for a BeGifted-owned Wise sandbox entity.",
+  };
+}
+
+export function isCreateInviteRequest(
+  payload: unknown,
+): payload is CreateInviteRequest {
+  if (typeof payload !== "object" || payload === null) {
+    return false;
+  }
+
+  const candidate = payload as Record<string, unknown>;
+
+  return (
+    typeof candidate.studentName === "string" &&
+    typeof candidate.parentEmail === "string" &&
+    typeof candidate.expiresAt === "string" &&
+    Array.isArray(candidate.assessmentVersionIds) &&
+    candidate.assessmentVersionIds.every(
+      (value) => typeof value === "string",
+    ) &&
+    (candidate.recipientEmails === undefined ||
+      (Array.isArray(candidate.recipientEmails) &&
+        candidate.recipientEmails.every((value) => typeof value === "string")))
+  );
+}

--- a/tests/wise-shadow.test.ts
+++ b/tests/wise-shadow.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { assertWiseSandboxEndpointAllowed } from "../apps/api/src/wise-sandbox.ts";
+import {
+  createWiseSandboxExternalRef,
+  createWiseSandboxStudentName,
+  evaluateWiseWriteGuard,
+  wiseSandboxOwner,
+} from "../packages/core/src/wise-shadow.ts";
+
+describe("wise shadow safety", () => {
+  it("anonymizes dummy student names before publishing to Wise", () => {
+    const displayName = createWiseSandboxStudentName("Alex Chen");
+    const externalRef = createWiseSandboxExternalRef("Alex Chen");
+
+    expect(displayName).toContain("BGT-DUMMY");
+    expect(displayName).toContain(externalRef.slice(-6).toUpperCase());
+    expect(displayName).not.toContain("Alex");
+    expect(displayName).not.toContain("Chen");
+  });
+
+  it("blocks mutations against non-owned Wise entities", () => {
+    const evaluation = evaluateWiseWriteGuard({
+      action: "publish-test",
+      entityType: "test",
+      targetWiseId: "test-live-123",
+      targetDisplayName: "Midterm Test",
+      bindings: [],
+    });
+
+    expect(evaluation.allowed).toBe(false);
+    expect(evaluation.dryRunOnly).toBe(true);
+  });
+
+  it("allows mutations only for BeGifted-owned sandbox entities", () => {
+    const evaluation = evaluateWiseWriteGuard({
+      action: "publish-test",
+      entityType: "test",
+      targetWiseId: "test-sandbox-123",
+      targetDisplayName: "BGT-TEST Year 7 Science Foundation Pre-Test",
+      bindings: [
+        {
+          wiseId: "test-sandbox-123",
+          entityType: "test",
+          owner: wiseSandboxOwner,
+          externalRef: "science-uk-year-7-foundation-pretest",
+          displayName: "BGT-TEST Year 7 Science Foundation Pre-Test",
+          createdAt: "2026-03-18T00:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(evaluation.allowed).toBe(true);
+    expect(evaluation.dryRunOnly).toBe(false);
+  });
+
+  it("blocks non-allowlisted Wise endpoints", () => {
+    expect(() =>
+      assertWiseSandboxEndpointAllowed("/institutes/abc/credits/grant"),
+    ).toThrow(/unsafe endpoint path/i);
+    expect(() =>
+      assertWiseSandboxEndpointAllowed("/user/classes/abc/roster"),
+    ).toThrow(/non-allowlisted endpoint path/i);
+  });
+});


### PR DESCRIPTION
Linked issue #8

## Summary
This PR implements a safe Wise shadow integration for BeGifted's pre-test platform. It adds a dummy-only Wise sandbox path so the team can validate invite creation, Wise launch, and submission ingestion without mutating any live Wise student, billing, class, fee, credit, or operational records.

For staff, this adds a BeGifted-managed sandbox invite flow for the seeded Year 7 Science Foundation pre-test. For students, this adds a token-validated launch page that resolves only to BeGifted-owned dummy Wise entities. Unsupported and subjective questions remain outside Wise and continue through the BeGifted grading and diagnostics path.

## Root Cause
The repo previously had invite and grading shells but no enforceable Wise boundary. There was no ownership model for BeGifted-created Wise objects, no path-level restriction on Wise endpoints, no sandbox invite API, and no student launch bridge. On a live Wise tenant, that left too much room for accidental writes to production records.

## Fix
The implementation adds a dedicated Wise sandbox module with code-enforced guardrails:

- Wise writes stay dry-run unless `WISE_SANDBOX_ALLOW_MUTATIONS=true`
- only BeGifted-owned dummy students, courses, and tests may be mutated after creation
- non-allowlisted or unsafe endpoint paths are rejected in code
- sandbox student identities are anonymized before they are sent to Wise
- submission sync is restricted to BeGifted-owned Wise sandbox tests

It also wires the new flow into the API and web app:

- `POST /api/invites`
- `GET /api/public/invites/:token`
- `GET /api/public/invites/:token/launch`
- `GET /api/wise/sandbox/account`
- `GET /api/wise/sandbox/logs`
- `POST /api/wise/sandbox/tests/:testId/submissions/sync`

The staff invite page now creates the sandbox invite against the seeded science assessment, and the student landing page validates the token before handing off to the sandbox launch bridge.

## Validation
This branch was verified with:

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run validate:content`
- `npm run build`

Additional tests cover endpoint allowlisting, ownership guards, invite creation and lookup, expired invites, and submission sync behavior.

## Handoff
- Issue: #8
- Branch: `codex/wise-shadow-sandbox-integration`
- Safe to merge: yes
- Residual risk: Wise bindings are still in-memory for the current prototype, so the next step is persistent sandbox binding storage before broader sandbox usage.
